### PR TITLE
[Bug Fix] - Auto-signout react sdk

### DIFF
--- a/echo-react-sdk/package.json
+++ b/echo-react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zdql/echo-react-sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "React SDK for Echo OAuth2 + PKCE authentication and token management",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/echo-react-sdk/src/stories/MockEchoProvider.tsx
+++ b/echo-react-sdk/src/stories/MockEchoProvider.tsx
@@ -41,6 +41,9 @@ const createMockContext = (
     console.log('Mock get token called');
     return 'mock-token';
   },
+  clearAuth: async () => {
+    console.log('Mock clear auth called');
+  },
   ...overrides,
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8324,14 +8324,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.3(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.3(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.2(@types/node@20.19.1)(typescript@5.8.3)
-      vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/mocker@3.2.3(msw@2.10.2(@types/node@24.0.3)(typescript@5.8.3))(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
@@ -8379,7 +8379,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.3(@types/node@20.19.1)(@vitest/ui@3.2.3)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.3(@types/node@24.0.3)(@vitest/ui@3.2.3)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.10.2(@types/node@24.0.3)(typescript@5.8.3))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/utils@3.0.9':
     dependencies:
@@ -12146,7 +12146,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.3
-      '@vitest/mocker': 3.2.3(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.3(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.3
       '@vitest/runner': 3.2.3
       '@vitest/snapshot': 3.2.3


### PR DESCRIPTION
Previously, if your silent authentication failed for whatever reason, it would brick the state of the provider due to the stale user and not allow you to sign back in without manually removing the localStorage token. 

A failed silent refresh will now auto-sign out the user and reset the provider.