### PR TITLE
add path data service

### DIFF
--- a/echo-server/src/clients/gpt-client.ts
+++ b/echo-server/src/clients/gpt-client.ts
@@ -7,7 +7,7 @@ async function makeRequest(useStreaming: boolean = false) {
   try {
     // Initialize OpenAI client with custom baseURL
     const openai = new OpenAI({
-      baseURL: 'http://localhost:3070',
+      baseURL: 'http://localhost:3070/5b20a7e2-f4eb-4879-b889-dc19148a6b06',
       apiKey: process.env.ECHO_API_KEY, // Required by the client but not used with local server
     });
 

--- a/echo-server/src/services/PathDataService.ts
+++ b/echo-server/src/services/PathDataService.ts
@@ -1,0 +1,64 @@
+/**
+ * Utility for extracting app ID from request paths
+ */
+
+export interface PathExtractionResult {
+  /** The extracted app ID if found, null otherwise */
+  appId: string | null;
+  /** The remaining path after removing the app ID segment */
+  remainingPath: string;
+}
+
+/**
+ * Extracts an app ID from the beginning of a request path if present.
+ *
+ * This function looks for a UUID pattern at the start of the path and treats it as an app ID.
+ * If found, it returns the app ID and the remaining path with the app ID segment removed.
+ *
+ * Examples:
+ * - `/12345678-1234-1234-1234-123456789012/v1/chat/completions`
+ *   → { appId: "12345678-1234-1234-1234-123456789012", remainingPath: "/v1/chat/completions" }
+ * - `/v1/chat/completions`
+ *   → { appId: null, remainingPath: "/v1/chat/completions" }
+ * - `/invalid-uuid/v1/chat/completions`
+ *   → { appId: null, remainingPath: "/invalid-uuid/v1/chat/completions" }
+ *
+ * @param originalPath - The original request path to process
+ * @returns Object containing the extracted app ID (if any) and the remaining path
+ */
+export function extractAppIdFromPath(
+  originalPath: string
+): PathExtractionResult {
+  // Remove leading slash and split by '/'
+  const pathSegments = originalPath.replace(/^\//, '').split('/');
+
+  // Check if the first segment looks like a UUID (app ID)
+  // UUID pattern: 8-4-4-4-12 characters (hexadecimal with hyphens)
+  const uuidPattern =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  if (
+    pathSegments.length > 0 &&
+    pathSegments[0] &&
+    uuidPattern.test(pathSegments[0])
+  ) {
+    const appId = pathSegments[0];
+    const remainingPath = '/' + pathSegments.slice(1).join('/');
+    return { appId, remainingPath };
+  }
+
+  // No app ID found, return original path
+  return { appId: null, remainingPath: originalPath };
+}
+
+/**
+ * Type guard to check if an extracted app ID is present
+ *
+ * @param result - The result from extractAppIdFromPath
+ * @returns True if app ID was extracted, false otherwise
+ */
+export function hasAppId(
+  result: PathExtractionResult
+): result is PathExtractionResult & { appId: string } {
+  return result.appId !== null;
+}

--- a/integration-tests/tests/echo-data-server/api-key.client.test.ts
+++ b/integration-tests/tests/echo-data-server/api-key.client.test.ts
@@ -1,5 +1,5 @@
 import { TEST_CONFIG } from '@/config/test-config';
-import { TEST_USER_API_KEYS } from '@/config/test-data';
+import { TEST_CLIENT_IDS, TEST_USER_API_KEYS } from '@/config/test-data';
 import { echoControlApi } from '@/utils/api-client';
 import OpenAI from 'openai';
 
@@ -111,5 +111,55 @@ describe('API Key Client', () => {
     expect(completion).toBeUndefined();
 
     console.log('✅ Invalid API key successfully rejected');
+  });
+
+  test('should be able to make a streaming LLM request with API key and app ID', async () => {
+    const apiKey = TEST_USER_API_KEYS.primary;
+    const balanceCheck = await echoControlApi.getBalance(apiKey);
+    expect(balanceCheck.totalPaid).toBeGreaterThan(0);
+
+    const openaiClient = new OpenAI({
+      baseURL: `${TEST_CONFIG.services.echoDataServer}/${TEST_CLIENT_IDS.primary}`,
+      apiKey: apiKey,
+    });
+
+    const stream = await openaiClient.chat.completions.create({
+      messages: [
+        { role: 'user', content: 'Tell me a short story about a cat!' },
+      ],
+      model: 'gpt-3.5-turbo',
+      stream: true,
+    });
+
+    expect(stream).toBeDefined();
+
+    let receivedContent = '';
+    let chunkCount = 0;
+
+    for await (const chunk of stream) {
+      chunkCount++;
+      expect(chunk).toBeDefined();
+      expect(chunk.choices).toBeDefined();
+      const content = chunk.choices[0]?.delta?.content || '';
+      receivedContent += content;
+    }
+
+    expect(chunkCount).toBeGreaterThan(0);
+    expect(receivedContent.length).toBeGreaterThan(0);
+
+    // await new Promise(resolve => setTimeout(resolve, 1000)); /// TODO BEN REALLY TODO: SPEED UP THE BALANCE UPDATE SO WE DON'T HAVE TO WAIT FOR 2 SECONDS
+
+    const secondBalanceCheck = await echoControlApi.getBalance(apiKey);
+    console.log('🔄 Second balance check: ', secondBalanceCheck);
+
+    expect(secondBalanceCheck.totalPaid).toBe(balanceCheck.totalPaid);
+    expect(secondBalanceCheck.totalSpent).toBeGreaterThan(
+      balanceCheck.totalSpent
+    );
+    expect(secondBalanceCheck.balance).toBeLessThan(balanceCheck.balance);
+
+    console.log(
+      '✅ Paid user (primary user) successfully made streaming LLM request and balance is updated'
+    );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,7 +463,7 @@ importers:
     dependencies:
       '@zdql/echo-react-sdk':
         specifier: file:../../echo-react-sdk
-        version: file:echo-react-sdk(openai@5.10.2(ws@8.18.2)(zod@3.25.76))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: file:echo-react-sdk(openai@5.11.0(ws@8.18.2)(zod@3.25.76))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next:
         specifier: ^14.2.30
         version: 14.2.30(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -570,7 +570,7 @@ importers:
     dependencies:
       '@zdql/echo-react-sdk':
         specifier: file:../../echo-react-sdk
-        version: file:echo-react-sdk(openai@5.10.2(ws@8.18.2)(zod@3.25.76))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: file:echo-react-sdk(openai@5.11.0(ws@8.18.2)(zod@3.25.76))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -5982,6 +5982,18 @@ packages:
       zod:
         optional: true
 
+  openai@5.11.0:
+    resolution: {integrity: sha512-+AuTc5pVjlnTuA9zvn8rA/k+1RluPIx9AD4eDcnutv6JNwHHZxIhkFy+tmMKCvmMFDQzfA/r1ujvPWB19DQkYg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -8254,7 +8266,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
       jest-regex-util: 30.0.1
 
   '@jest/reporters@29.7.0':
@@ -8349,7 +8361,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -10018,7 +10030,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/bunyan@1.8.11':
     dependencies:
@@ -10035,7 +10047,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/cookie@0.6.0': {}
 
@@ -10228,12 +10240,12 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
       '@types/send': 0.17.5
 
   '@types/shimmer@1.2.0': {}
@@ -10260,7 +10272,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -10613,7 +10625,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@zdql/echo-react-sdk@file:echo-react-sdk(openai@5.10.2(ws@8.18.2)(zod@3.25.76))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@zdql/echo-react-sdk@file:echo-react-sdk(openai@5.11.0(ws@8.18.2)(zod@3.25.76))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@zdql/echo-typescript-sdk': 1.0.18
       dompurify: 3.2.6
@@ -10621,7 +10633,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
-      openai: 5.10.2(ws@8.18.2)(zod@3.25.76)
+      openai: 5.11.0(ws@8.18.2)(zod@3.25.76)
     transitivePeerDependencies:
       - debug
 
@@ -12852,7 +12864,7 @@ snapshots:
   jest-mock@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
       jest-util: 30.0.5
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -12972,7 +12984,7 @@ snapshots:
   jest-util@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
       chalk: 4.1.2
       ci-info: 4.3.0
       graceful-fs: 4.2.11
@@ -13672,6 +13684,12 @@ snapshots:
     optionalDependencies:
       ws: 8.18.2
       zod: 3.25.76
+
+  openai@5.11.0(ws@8.18.2)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.18.2
+      zod: 3.25.76
+    optional: true
 
   optionator@0.9.4:
     dependencies:


### PR DESCRIPTION
Adds the path data service. This allows you to bundle your App ID with your distributed CLI app, ensuring that users can only authenticate with APIs for your specific application. 

The Echo Router can still handle requests that do not begin with an App Id. In the case of JWT authed apps, this is a better approach. 