### PR TITLE
fallback to client_id from search params token endpoint

### DIFF
--- a/echo-control/src/app/api/oauth/token/route.ts
+++ b/echo-control/src/app/api/oauth/token/route.ts
@@ -18,7 +18,10 @@ export async function POST(req: NextRequest) {
       body = await req.json();
     }
 
-    const { grant_type, code, redirect_uri, client_id, code_verifier } = body;
+    const { grant_type, code, redirect_uri, code_verifier } = body;
+
+    const client_id =
+      body.client_id || req.nextUrl.searchParams.get('client_id');
 
     // Validate required parameters
     if (grant_type !== 'authorization_code' && grant_type !== 'refresh_token') {


### PR DESCRIPTION
NextAuth does not support adding additional fields to the body of `/token` requests (they used to in v4, v5 does not)

They do not pass `client_id` in the body of the request either for some reason.

The author of the library says they do not support it because "We don't really want people to patch the standard OAuth token request" [here](https://github.com/nextauthjs/next-auth/issues/10732#issuecomment-2082463907)

I am not familiar with what is standard in this realm.

This just allows me to pass the `client_id` in the query params as a fallback if it is not in the body.

@rsproule @sragss is there a security concern with this?

I will keep digging to see if there is a better workaround but gonna roll with this for now.