### PR TITLE
bring the middleware back

### DIFF
--- a/echo-control/package.json
+++ b/echo-control/package.json
@@ -50,6 +50,7 @@
     "nanoid": "^5.1.5",
     "next": "15.3.3",
     "next-auth": "5.0.0-beta.29",
+    "next-path-matcher": "^1.0.2",
     "next-themes": "^0.4.6",
     "postcss": "^8.5.4",
     "prisma": "^6.8.2",

--- a/echo-control/src/middleware.ts
+++ b/echo-control/src/middleware.ts
@@ -1,0 +1,40 @@
+import { createPathMatcher } from 'next-path-matcher';
+
+import { auth } from '@/auth';
+import { NextResponse } from 'next/server';
+
+const isPublicRoute = createPathMatcher([
+  '/',
+  '/api/auth/(.*)',
+  '/api/v1/(.*)',
+  '/api/oauth(.*)',
+  '/api/validate-jwt-token(.*)',
+  '/sign-in(.*)',
+  '/sign-up(.*)',
+  '/api/apps/public',
+  '/api/stripe/webhook(.*)',
+  '/api/validate-jwt-token(.*)', // Fast JWT validation endpoint - no auth needed
+  '/api/oauth/authorize(.*)', // OAuth authorize endpoint - handles its own auth
+  '/api/oauth/token(.*)', // OAuth token endpoint - handles its own auth
+  '/api/health(.*)', // Health check endpoint - no auth needed
+]);
+
+export default auth(req => {
+  if (isPublicRoute(req)) {
+    return NextResponse.next();
+  }
+
+  console.log('req.auth', req.auth);
+
+  if (!req.auth) {
+    const newUrl = new URL('/sign-in', req.nextUrl.origin);
+    return Response.redirect(newUrl);
+  }
+});
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals and all static files, unless found in search params
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+  ],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       next-auth:
         specifier: 5.0.0-beta.29
         version: 5.0.0-beta.29(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      next-path-matcher:
+        specifier: ^1.0.2
+        version: 1.0.2(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -5880,6 +5883,12 @@ packages:
         optional: true
       nodemailer:
         optional: true
+
+  next-path-matcher@1.0.2:
+    resolution: {integrity: sha512-13WyBGD/IJuLQnhPTGI9CtwCztH0FysCqwY1QlIrIzJt0LjOsip/Btw+UDykXWfPLsAgmwyaAR71Qxezv0cY1A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      next: '>=15'
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -13620,6 +13629,11 @@ snapshots:
       '@auth/core': 0.40.0
       next: 15.3.3(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
+
+  next-path-matcher@1.0.2(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      next: 15.3.3(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      path-to-regexp: 6.3.0
 
   next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
Okay so the Clerk middleware I removed in https://github.com/Merit-Systems/echo/pull/134 did serve one purpose which was nice: redirecting when a user tries to hit a page that needs auth.

This PR brings back the middleware with the same routes but does not handle the CORS (as that is now in the `next.config.ts`

I would like to move away from this long term in favor of checking the session on each page, but currently **all of the pages are client-side` so that would be a fairly large refactor.

So for now we keep the middleware but expect to remove this once I migrate all of the pages to server-rendered.