### PR TITLE
[Feature] Update your Free Tier with your Echo Balance

### DIFF
--- a/packages/app/control/docs/advanced/meta.json
+++ b/packages/app/control/docs/advanced/meta.json
@@ -1,4 +1,9 @@
 {
-  "pages": ["how-echo-works", "api-reference", "callback-urls", "system-prompt"],
+  "pages": [
+    "how-echo-works",
+    "api-reference",
+    "callback-urls",
+    "system-prompt"
+  ],
   "icon": "Brain"
 }

--- a/packages/app/control/prisma/migrations/20250916152300_add_balance_enum/migration.sql
+++ b/packages/app/control/prisma/migrations/20250916152300_add_balance_enum/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "public"."EnumPaymentSource" ADD VALUE 'balance';

--- a/packages/app/control/prisma/schema.prisma
+++ b/packages/app/control/prisma/schema.prisma
@@ -283,6 +283,7 @@ enum EnumPaymentSource {
   stripe
   admin
   signUpGift
+  balance
 }
 
 model Transaction {

--- a/packages/app/control/src/app/(app)/(home)/credits/_components/balance/add-credits.tsx
+++ b/packages/app/control/src/app/(app)/(home)/credits/_components/balance/add-credits.tsx
@@ -5,11 +5,12 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { MoneyInput } from '@/components/ui/money-input';
 
-import { Check, Loader2 } from 'lucide-react';
+import { AlertCircle, Check, Loader2 } from 'lucide-react';
 import { api } from '@/trpc/client';
 
 export const AddCredits = () => {
   const [amount, setAmount] = useState<number>();
+  const [error, setError] = useState<string | null>(null);
 
   const {
     mutate: createPaymentLink,
@@ -18,6 +19,9 @@ export const AddCredits = () => {
   } = api.user.payments.createLink.useMutation({
     onSuccess: data => {
       window.location.href = data.paymentLink.url;
+    },
+    onError: error => {
+      setError(error.message || 'Failed to create payment link');
     },
   });
 
@@ -37,6 +41,12 @@ export const AddCredits = () => {
         min="1"
         step="0.01"
       />
+      {error && (
+        <div className="flex items-center gap-2 p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md">
+          <AlertCircle className="size-4 flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
       <Button
         onClick={onAddCredits}
         disabled={isPending || !amount || amount <= 0 || isSuccess}

--- a/packages/app/control/src/app/(app)/app/[id]/(overview)/_components/header/index.tsx
+++ b/packages/app/control/src/app/(app)/app/[id]/(overview)/_components/header/index.tsx
@@ -60,11 +60,15 @@ export const HeaderCard: React.FC<Props> = ({ appId }) => {
       <div className="grid grid-cols-1 md:grid-cols-7">
         <div className="flex flex-col gap-4 p-4 pt-12 md:pt-14 col-span-5">
           <div className="">
-            <h1 className="text-3xl font-bold break-words line-clamp-2">{app.name}</h1>
+            <h1 className="text-3xl font-bold break-words line-clamp-2">
+              {app.name}
+            </h1>
             <p
               className={cn(
                 'break-words line-clamp-2',
-                app.description ? 'text-muted-foreground' : 'text-muted-foreground/40'
+                app.description
+                  ? 'text-muted-foreground'
+                  : 'text-muted-foreground/40'
               )}
             >
               {app.description ?? 'No description'}

--- a/packages/app/control/src/app/(app)/app/[id]/(overview)/_components/header/index.tsx
+++ b/packages/app/control/src/app/(app)/app/[id]/(overview)/_components/header/index.tsx
@@ -60,13 +60,12 @@ export const HeaderCard: React.FC<Props> = ({ appId }) => {
       <div className="grid grid-cols-1 md:grid-cols-7">
         <div className="flex flex-col gap-4 p-4 pt-12 md:pt-14 col-span-5">
           <div className="">
-            <h1 className="text-3xl font-bold">{app.name}</h1>
+            <h1 className="text-3xl font-bold break-words line-clamp-2">{app.name}</h1>
             <p
-              className={
-                app.description
-                  ? 'text-muted-foreground'
-                  : 'text-muted-foreground/40'
-              }
+              className={cn(
+                'break-words line-clamp-2',
+                app.description ? 'text-muted-foreground' : 'text-muted-foreground/40'
+              )}
             >
               {app.description ?? 'No description'}
             </p>

--- a/packages/app/control/src/app/(app)/app/[id]/free-tier/_components/balance/add-credits.tsx
+++ b/packages/app/control/src/app/(app)/app/[id]/free-tier/_components/balance/add-credits.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { MoneyInput } from '@/components/ui/money-input';
 
-import { Check, Loader2 } from 'lucide-react';
+import { Check, Loader2, AlertCircle } from 'lucide-react';
 import { api } from '@/trpc/client';
 
 interface Props {
@@ -14,6 +14,11 @@ interface Props {
 
 export const AddCredits: React.FC<Props> = ({ appId }) => {
   const [amount, setAmount] = useState<number>();
+  const [error, setError] = useState<string | null>(null);
+  const [isSuccessFromBalance, setIsSuccessFromBalance] =
+    useState<boolean>(false);
+
+  const utils = api.useUtils();
 
   const {
     mutate: createPaymentLink,
@@ -21,15 +26,53 @@ export const AddCredits: React.FC<Props> = ({ appId }) => {
     isSuccess,
   } = api.apps.app.freeTier.payments.create.useMutation({
     onSuccess: data => {
+      setError(null);
       window.location.href = data.paymentLink.url;
+    },
+    onError: error => {
+      setError(error.message || 'Failed to create payment link');
+    },
+  });
+
+  const {
+    mutate: createPaymentFromBalance,
+    isPending: isPendingFromBalance,
+    error: balancePaymentError,
+  } = api.apps.app.freeTier.payments.createFromBalance.useMutation({
+    onSuccess: data => {
+      if (!data.success) {
+        setError(data.error_message || 'Payment failed');
+        return;
+      }
+      setError(null);
+      setIsSuccessFromBalance(true);
+
+      // Invalidate balance queries
+      utils.user.balance.get.invalidate();
+      utils.user.balance.app.free.invalidate({ appId });
+      utils.apps.app.freeTier.get.invalidate({ appId });
+    },
+    onError: error => {
+      setError(error.message || 'Failed to process payment from balance');
     },
   });
 
   const onAddCredits = () => {
-    if (!amount) {
-      throw new Error('Amount is required');
+    if (!amount || amount <= 0) {
+      setError('Please enter a valid amount');
+      return;
     }
+    setError(null);
     createPaymentLink({ appId, amount });
+  };
+
+  const onAddCreditsFromBalance = () => {
+    if (!amount || amount <= 0) {
+      setError('Please enter a valid amount');
+      return;
+    }
+    setError(null);
+    createPaymentFromBalance({ appId, amountInDollars: amount });
   };
 
   return (
@@ -41,20 +84,51 @@ export const AddCredits: React.FC<Props> = ({ appId }) => {
         min="1"
         step="0.01"
       />
-      <Button
-        onClick={onAddCredits}
-        disabled={isPending || !amount || amount <= 0 || isSuccess}
-        size="lg"
-        variant="turbo"
-      >
-        {isPending ? (
-          <Loader2 className="size-4 animate-spin" />
-        ) : isSuccess ? (
-          <Check className="size-4" />
-        ) : (
-          'Add Credits'
-        )}
-      </Button>
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md">
+          <AlertCircle className="size-4 flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <Button
+          onClick={onAddCredits}
+          disabled={isPending || !amount || amount <= 0 || isSuccess}
+          size="lg"
+          variant="turbo"
+          className="flex-1"
+        >
+          {isPending ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : isSuccess ? (
+            <Check className="size-4" />
+          ) : (
+            'Add Credits'
+          )}
+        </Button>
+        <Button
+          onClick={onAddCreditsFromBalance}
+          disabled={
+            isPendingFromBalance ||
+            !amount ||
+            amount <= 0 ||
+            isSuccessFromBalance
+          }
+          size="lg"
+          variant="turbo"
+          className="flex-1"
+        >
+          {isPendingFromBalance ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : isSuccessFromBalance && !balancePaymentError ? (
+            <Check className="size-4" />
+          ) : (
+            'Add Credits From Balance'
+          )}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/packages/app/control/src/app/(app)/app/[id]/free-tier/_components/balance/add-credits.tsx
+++ b/packages/app/control/src/app/(app)/app/[id]/free-tier/_components/balance/add-credits.tsx
@@ -75,6 +75,8 @@ export const AddCredits: React.FC<Props> = ({ appId }) => {
     createPaymentFromBalance({ appId, amountInDollars: amount });
   };
 
+  const [currentUserBalance] = api.user.balance.get.useSuspenseQuery();
+
   return (
     <div className="flex flex-col w-full gap-4">
       <MoneyInput
@@ -95,9 +97,9 @@ export const AddCredits: React.FC<Props> = ({ appId }) => {
       <div className="flex gap-3">
         <Button
           onClick={onAddCredits}
-          disabled={isPending || !amount || amount <= 0 || isSuccess}
+          disabled={isPending || !amount || amount < 1 || isSuccess}
           size="lg"
-          variant="turbo"
+          variant="turboSecondary"
           className="flex-1"
         >
           {isPending ? (
@@ -113,8 +115,9 @@ export const AddCredits: React.FC<Props> = ({ appId }) => {
           disabled={
             isPendingFromBalance ||
             !amount ||
-            amount <= 0 ||
-            isSuccessFromBalance
+            amount < 0 ||
+            isSuccessFromBalance ||
+            currentUserBalance.balance < amount
           }
           size="lg"
           variant="turbo"

--- a/packages/app/control/src/app/(app)/app/[id]/free-tier/_components/balance/index.tsx
+++ b/packages/app/control/src/app/(app)/app/[id]/free-tier/_components/balance/index.tsx
@@ -13,8 +13,10 @@ import {
   DialogTitle,
   DialogDescription,
   DialogTrigger,
+  DialogFooter,
 } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Balance as BalanceDisplay } from '@/app/(app)/_components/layout/header/balance/balance-display';
 
 import { AddCredits } from './add-credits';
 
@@ -29,7 +31,9 @@ interface Props {
 const BalanceContainer = ({ children }: { children: React.ReactNode }) => {
   return (
     <Card className="border rounded-lg overflow-hidden flex flex-col gap-2 p-4">
-      <h1 className="text-lg font-semibold text-muted-foreground">Balance</h1>
+      <h1 className="text-lg font-semibold text-muted-foreground">
+        Free Tier Balance
+      </h1>
       <div className="flex items-center gap-4 w-full">{children}</div>
     </Card>
   );
@@ -58,6 +62,12 @@ export const Balance: React.FC<Props> = ({ appId }) => {
               Your users will be able to use free tier credits before they have
               to buy credits and spend their Echo balance.
             </DialogDescription>
+            <DialogFooter>
+              <span className="text-sm font-semibold text-muted-foreground">
+                Current Balance:
+              </span>
+              <BalanceDisplay />
+            </DialogFooter>
           </DialogHeader>
           <AddCredits appId={appId} />
         </DialogContent>

--- a/packages/app/control/src/components/ui/button.tsx
+++ b/packages/app/control/src/components/ui/button.tsx
@@ -32,6 +32,15 @@ const buttonVariants = cva(
           'before:content-[""] before:absolute before:w-full before:h-full before:rounded-md before:pointer-events-none',
           'before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent before:animate-shimmer'
         ),
+        turboSecondary: cn(
+          'bg-gradient-to-br from-gray-400 via-gray-500 to-gray-600 text-white hover:opacity-90',
+          'shadow-[0_2px_6px_color-mix(in_oklab,theme(colors.gray.500)_70%,transparent)]',
+          'hover:shadow-[0_2px_4px_color-mix(in_oklab,theme(colors.gray.500)_70%,transparent)]',
+          'inset-ring-2 inset-ring-inset inset-ring-border/50',
+          'relative overflow-hidden',
+          'before:content-[""] before:absolute before:w-full before:h-full before:rounded-md before:pointer-events-none',
+          'before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent before:animate-shimmer'
+        ),
         unstyled: '',
       },
       size: {

--- a/packages/app/control/src/services/credits.ts
+++ b/packages/app/control/src/services/credits.ts
@@ -3,8 +3,16 @@ import z from 'zod';
 import { db } from '@/lib/db';
 import { processPaymentUpdate, PaymentStatus } from '@/lib/payment-processing';
 
-import { EnumPaymentSource, type Prisma } from '@/generated/prisma';
+import {
+  EnumPaymentSource,
+  Payment,
+  Session,
+  type Prisma,
+} from '@/generated/prisma';
 import { logger } from '@/logger';
+import { updateSpendPoolFromPayment } from '@/lib/spend-pools';
+import { Decimal } from '@/generated/prisma/runtime/library';
+import { User } from '@auth/core/types';
 
 export const mintCreditsToUserSchema = z.object({
   userId: z.uuid(),
@@ -121,3 +129,138 @@ export const mintCreditsToUser = async (
     isFreeTier,
   };
 };
+
+export const createFreeTierPaymentFromBalanceSchema = z.object({
+  appId: z.string(),
+  amountInDollars: z.number(),
+});
+
+export async function createFreeTierPaymentFromBalance(
+  ctx: { session: { user: User } },
+  input: z.infer<typeof createFreeTierPaymentFromBalanceSchema>
+): Promise<{
+  success: boolean;
+  freeTierPayment: Payment | null;
+  error_message: string | null;
+}> {
+  const validationResult =
+    createFreeTierPaymentFromBalanceSchema.safeParse(input);
+
+  if (!validationResult.success) {
+    logger.emit({
+      severityText: 'ERROR',
+      body: 'Invalid input for credit minting',
+      attributes: {
+        validationError: validationResult.error.message,
+        input: JSON.stringify(input),
+        function: 'createFreeTierPaymentFromBalance',
+      },
+    });
+    throw new Error(validationResult.error.message, {
+      cause: validationResult.error,
+    });
+  }
+
+  const { appId, amountInDollars } = validationResult.data;
+  const echoAppId = await db.echoApp.findUnique({
+    where: { id: appId },
+  });
+
+  if (!echoAppId) {
+    throw new Error('Echo app not found');
+  }
+
+  const userId = ctx.session.user.id;
+
+  if (!userId) {
+    throw new Error('User not found');
+  }
+
+  const amountInDollarsDecimal = new Decimal(amountInDollars);
+  const amountInCentsDecimal = amountInDollarsDecimal.mul(100);
+
+  const freeTierPaymentId = `free_tier_from_balance_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+  const result = await db.$transaction(async tx => {
+    // check if the user has enough balance
+    const user = await tx.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      return {
+        success: false,
+        freeTierPayment: null,
+        error_message: 'User not found',
+      };
+    }
+
+    const currentUserBalance = user.totalPaid.minus(user.totalSpent);
+
+    if (currentUserBalance < amountInDollarsDecimal) {
+      return {
+        success: false,
+        freeTierPayment: null,
+        error_message: 'Insufficient balance to complete transaction.',
+      };
+    }
+
+    const freeTierPayment = await tx.payment.create({
+      data: {
+        paymentId: freeTierPaymentId,
+        userId: userId,
+        amount: amountInDollars,
+        currency: 'usd',
+        status: PaymentStatus.COMPLETED,
+        source: EnumPaymentSource.balance,
+        description: 'Free Tier Credit Redemption Payment from Balance',
+      },
+    });
+
+    await updateSpendPoolFromPayment(
+      tx,
+      echoAppId.id,
+      freeTierPayment,
+      Number(amountInCentsDecimal),
+      {}
+    );
+
+    // decrement the user's balance
+    await tx.user.update({
+      where: { id: userId },
+      data: {
+        totalSpent: {
+          increment: amountInDollarsDecimal,
+        },
+      },
+    });
+    const transactionMetadata = await tx.transactionMetadata.create({
+      data: {
+        providerId: freeTierPaymentId,
+        provider: 'balance_transfer',
+        model: 'balance_transfer',
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      },
+    });
+    await tx.transaction.create({
+      data: {
+        userId,
+        totalCost: amountInDollarsDecimal,
+        rawTransactionCost: amountInDollarsDecimal,
+        status: 'success',
+        echoAppId: echoAppId.id,
+        transactionMetadataId: transactionMetadata.id,
+      },
+    });
+
+    return {
+      success: true,
+      freeTierPayment,
+      error_message: null,
+    };
+  });
+
+  return result;
+}

--- a/packages/app/control/src/services/stripe.ts
+++ b/packages/app/control/src/services/stripe.ts
@@ -14,7 +14,7 @@ const stripe = new Stripe(
 );
 
 export const createPaymentLinkSchema = z.object({
-  amount: z.number().min(1),
+  amount: z.number(),
   description: z.string().optional(),
   successUrl: z.url().optional(),
 });
@@ -27,7 +27,7 @@ export async function createPaymentLink(
     successUrl,
   }: z.infer<typeof createPaymentLinkSchema>
 ) {
-  if (amount <= 0) {
+  if (amount < 1) {
     logger.emit({
       severityText: 'WARN',
       body: 'Invalid amount for payment link creation',
@@ -37,7 +37,7 @@ export async function createPaymentLink(
         function: 'createPaymentLink',
       },
     });
-    throw new Error('Valid amount is required');
+    throw new Error('A minimum of 1 dollar is required to purchase credits');
   }
 
   logger.emit({
@@ -154,8 +154,10 @@ export async function createFreeTierPaymentLink(
     appId,
   }: z.infer<typeof createFreeTierPaymentLinkSchema>
 ) {
-  if (amount <= 0) {
-    throw new Error('Valid amount is required');
+  if (amount < 1) {
+    throw new Error(
+      'A minimum of 1 dollar is required to purchase free tier credits'
+    );
   }
 
   // Verify the app exists and user has access

--- a/packages/app/control/src/trpc/routers/apps/index.ts
+++ b/packages/app/control/src/trpc/routers/apps/index.ts
@@ -91,6 +91,10 @@ import {
   getUserAppReferralCode,
 } from '@/services/apps/referral-code';
 import { deleteApp, deleteAppSchema } from '@/services/apps/delete';
+import {
+  createFreeTierPaymentFromBalance,
+  createFreeTierPaymentFromBalanceSchema,
+} from '@/services/credits';
 
 export const appsRouter = createTRPCRouter({
   create: protectedProcedure
@@ -180,6 +184,12 @@ export const appsRouter = createTRPCRouter({
           .input(createFreeTierPaymentLinkSchema)
           .mutation(async ({ ctx, input }) => {
             return await createFreeTierPaymentLink(ctx.session.user.id, input);
+          }),
+
+        createFromBalance: appOwnerProcedure
+          .input(createFreeTierPaymentFromBalanceSchema)
+          .mutation(async ({ ctx, input }) => {
+            return await createFreeTierPaymentFromBalance(ctx, input);
           }),
       },
 

--- a/templates/next/next.config.ts
+++ b/templates/next/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */

--- a/templates/react/README.md
+++ b/templates/react/README.md
@@ -36,15 +36,15 @@ export default tseslint.config([
       // other options...
     },
   },
-])
+]);
 ```
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+import reactX from 'eslint-plugin-react-x';
+import reactDom from 'eslint-plugin-react-dom';
 
 export default tseslint.config([
   globalIgnores(['dist']),
@@ -65,5 +65,5 @@ export default tseslint.config([
       // other options...
     },
   },
-])
+]);
 ```

--- a/templates/react/eslint.config.js
+++ b/templates/react/eslint.config.js
@@ -1,9 +1,9 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { globalIgnores } from 'eslint/config'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import { globalIgnores } from 'eslint/config';
 
 export default tseslint.config([
   globalIgnores(['dist']),
@@ -20,4 +20,4 @@ export default tseslint.config([
       globals: globals.browser,
     },
   },
-])
+]);

--- a/templates/react/vite.config.ts
+++ b/templates/react/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});


### PR DESCRIPTION
The flow here is: 

1. Check user balance and confirm they have sufficient to spend
2. Create a free tier payment 
3. Create a transaction debiting their spend on this app with provider: "balance_transfer"
** This kind of overloads the transactions table, but I think it is the right abstraction because you are spending your balance on the app. 
4. Invalidate the balance and free tier balance queries on the FE

Also improved the error handling for invalid amounts here and in the balance component @jasonhedman 

Added a small migration which adds the enum for a payment from "balance".

<img width="711" height="406" alt="Screenshot 2025-09-16 at 12 15 01 PM" src="https://github.com/user-attachments/assets/450029f9-b129-4438-93aa-6cb5e0f065ab" />
