### PR TITLE
fix: fetch UserId on generate video

### DIFF
--- a/packages/app/server/src/server.ts
+++ b/packages/app/server/src/server.ts
@@ -85,7 +85,7 @@ app.all('*', async (req: EscrowRequest, res: Response, next: NextFunction) => {
     const headers = req.headers as Record<string, string>;
     const { provider, isStream, isPassthroughProxyRoute } =
       await initializeProvider(req, res);
-    const maxCost = getRequestMaxCost(req, provider);
+    const maxCost = getRequestMaxCost(req, provider, isPassthroughProxyRoute);
 
     if (!isApiRequest(headers) && !isX402Request(headers)) {
       return buildX402Response(req, res, maxCost);
@@ -96,6 +96,7 @@ app.all('*', async (req: EscrowRequest, res: Response, next: NextFunction) => {
       prisma
     );
 
+    provider.setEchoControlService(echoControlService);
     if (isX402Request(headers)) {
       await handleX402Request({
         req,

--- a/packages/app/server/src/services/PricingService.ts
+++ b/packages/app/server/src/services/PricingService.ts
@@ -16,7 +16,8 @@ import { Tool } from 'openai/resources/responses/responses';
 
 export function getRequestMaxCost(
   req: EscrowRequest,
-  provider: BaseProvider
+  provider: BaseProvider,
+  isPassthroughProxyRoute: boolean
 ): Decimal {
   // Need to switch between language/image/video for different pricing models.
   if (isValidVideoModel(provider.getModel())) {
@@ -61,6 +62,9 @@ export function getRequestMaxCost(
     const maxOutputTokens = extractMaxOutputTokens(req);
     const modelWithPricing = getModelPrice(provider.getModel());
     if (!modelWithPricing) {
+      if (isPassthroughProxyRoute) {
+        return new Decimal(0);
+      }
       throw new UnknownModelError(`Invalid model: ${provider.getModel()}`);
     }
     const maxInputCost = new Decimal(maxInputTokens).mul(


### PR DESCRIPTION
We pretty much deprecated the echoControlService in all provider and since we initialize the provider before the echoControlService was being passed we could not fetch the userId. 

In this PR we are just going to override the provider.echoControlService once initialized (only happens on non x402 routes) so we can do proper fetching.