### PR TITLE
Markup for x402 and batched fundRepo event

### DIFF
--- a/packages/app/server/src/services/PricingService.ts
+++ b/packages/app/server/src/services/PricingService.ts
@@ -15,6 +15,12 @@ import { ProviderType } from 'providers/ProviderType';
 import { Tool } from 'openai/resources/responses/responses';
 import { SupportedVideoModel } from '@merit-systems/echo-typescript-sdk';
 
+export function applyMaxCostMarkup(maxCost: Decimal): Decimal {
+  const markup = process.env.MAX_COST_MARKUP || '1.25';
+  return maxCost.mul(new Decimal(markup));
+}
+
+
 export function getRequestMaxCost(
   req: EscrowRequest,
   provider: BaseProvider,

--- a/packages/app/server/src/services/fund-repo/constants.ts
+++ b/packages/app/server/src/services/fund-repo/constants.ts
@@ -85,3 +85,4 @@ export const ERC3009_ABI = [
 export const MERIT_CONTRACT_ADDRESS = process.env
   .MERIT_CONTRACT_ADDRESS as `0x${string}`;
 export const USDC_ADDRESS = process.env.USDC_ADDRESS as `0x${string}`;
+export const ETH_ADDRESS = process.env.ETH_ADDRESS as `0x${string}`;

--- a/packages/app/server/src/utils.ts
+++ b/packages/app/server/src/utils.ts
@@ -64,6 +64,13 @@ export function usdcBigIntToDecimal(usdcBigInt: bigint | string): Decimal {
   return new Decimal(decimalValue);
 }
 
+export function bigIntToDecimal(bigInt: bigint | string, decimals: number): Decimal {
+  const bigIntValue =
+    typeof bigInt === 'string' ? BigInt(bigInt) : bigInt;
+  const decimalValue = Number(bigIntValue) / (10 ** decimals);
+  return new Decimal(decimalValue);
+}
+
 /**
  * Calculates the refund amount for an x402 request. Also used to log when we underestimate the cost.
  * @param maxCost The max cost of the request


### PR DESCRIPTION
Adds a mark-up to our x402 invocations of 25% by default, or decided by an env var. 

This also batches the sending of funds to the fundRepo contract, to only in batches of 100 USD. If less, or out of ethereum, it logs a metric and passes. 

In order to add sophisticated profit tracking, we will need to add a table of x402 transactions. We will also need to add a way of determining where the funds should be distributed. 

new envs: 
ETH_ADDRESS
MAX_COST_MARKUP
