### PR TITLE
 External Template Support in echo-start

### DIFF
--- a/packages/sdk/echo-start/src/index.ts
+++ b/packages/sdk/echo-start/src/index.ts
@@ -171,10 +171,8 @@ interface CreateAppOptions {
 
 function isExternalTemplate(template: string): boolean {
   return (
-    template.includes('/') ||
-    template.includes('#') ||
-    template.startsWith('http://') ||
-    template.startsWith('https://')
+    template.startsWith('https://github.com/') ||
+    template.startsWith('http://github.com/')
   );
 }
 
@@ -477,7 +475,7 @@ async function main() {
     .argument('[directory]', 'Directory to create the app in')
     .option(
       '-t, --template <template>',
-      `Template to use. Can be a preset (${Object.keys(DEFAULT_TEMPLATES).join(', ')}) or an external GitHub repository (user/repo, user/repo/subdirectory, user/repo#branch, https://github.com/user/repo)`
+      `Template to use. Can be a preset (${Object.keys(DEFAULT_TEMPLATES).join(', ')}) or a GitHub repository URL (https://github.com/user/repo)`
     )
     .option('-a, --app-id <appId>', 'Echo App ID to use in the project')
     .option('--skip-install', 'Skip automatic dependency installation')


### PR DESCRIPTION
closes #611 

Adds support for using external GitHub repositories as templates in echo-start, while maintaining full backward compatibility with existing preset templates.

usage 

```# Preset templates (existing behavior)
npx echo-start my-app --template next

# GitHub shorthand
npx echo-start my-app --template user/repo

# With subdirectory
npx echo-start my-app --template user/repo/templates/starter

# With branch/tag
npx echo-start my-app --template user/repo#develop

# Full GitHub URL
npx echo-start my-app --template https://github.com/user/repo
```

Tested with: 
✅ sragss/echo-nano-banana - Vite project, auto-detected VITE_ECHO_APP_ID from existing env files
✅ rsproule/shirtslop - Vite project, auto-created .env.local with VITE_ECHO_APP_ID
✅ briansproule20/echo-trivia/echo-trivia - Next.js subdirectory, auto-created .env.local with NEXT_PUBLIC_ECHO_APP_ID
✅ Trynax/commitcraft - Existing .env.local with ECHO_APP_ID, correctly detected and updated
✅ All existing preset templates - Verified backward compatibility (next, assistant-ui, etc.)