### PR TITLE
Fix React Server Components CVE vulnerabilities in remaining templates

### DIFF
--- a/templates/assistant-ui/package.json
+++ b/templates/assistant-ui/package.json
@@ -16,7 +16,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",
-    "next": "15.4.10",
+    "next": "15.5.4",
     "postcss": "^8.5.6",
     "react": "19.1.1",
     "react-dom": "19.1.1",
@@ -30,7 +30,7 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "eslint": "^9",
-    "eslint-config-next": "15.4.10",
+    "eslint-config-next": "15.5.4",
     "tw-animate-css": "^1.3.6",
     "typescript": "^5.9.2"
   },

--- a/templates/assistant-ui/package.json
+++ b/templates/assistant-ui/package.json
@@ -16,7 +16,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",
-    "next": "15.5.4",
+    "next": "15.5.9",
+    "openai": "^4.77.0",
     "postcss": "^8.5.6",
     "react": "19.1.1",
     "react-dom": "19.1.1",
@@ -30,7 +31,7 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "eslint": "^9",
-    "eslint-config-next": "15.5.4",
+    "eslint-config-next": "15.5.9",
     "tw-animate-css": "^1.3.6",
     "typescript": "^5.9.2"
   },

--- a/templates/next-image/package.json
+++ b/templates/next-image/package.json
@@ -24,7 +24,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.263.1",
     "nanoid": "^5.1.5",
-    "next": "15.5.4",
+    "next": "15.5.9",
     "openai": "^5.20.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -37,7 +37,7 @@
     "@types/react": "19.1.10",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.5.4",
+    "eslint-config-next": "15.5.9",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5"

--- a/templates/next-image/package.json
+++ b/templates/next-image/package.json
@@ -24,7 +24,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.263.1",
     "nanoid": "^5.1.5",
-    "next": "15.4.10",
+    "next": "15.5.4",
     "openai": "^5.20.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -37,7 +37,7 @@
     "@types/react": "19.1.10",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.4.10",
+    "eslint-config-next": "15.5.4",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5"

--- a/templates/next-video-template/package.json
+++ b/templates/next-video-template/package.json
@@ -28,7 +28,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.263.1",
     "nanoid": "^5.1.5",
-    "next": "15.5.4",
+    "next": "15.5.9",
     "openai": "^5.20.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -41,7 +41,7 @@
     "@types/react": "19.1.10",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.5.4",
+    "eslint-config-next": "15.5.9",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5"

--- a/templates/next-video-template/package.json
+++ b/templates/next-video-template/package.json
@@ -28,7 +28,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.263.1",
     "nanoid": "^5.1.5",
-    "next": "15.4.10",
+    "next": "15.5.4",
     "openai": "^5.20.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -41,7 +41,7 @@
     "@types/react": "19.1.10",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.4.10",
+    "eslint-config-next": "15.5.4",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5"


### PR DESCRIPTION
## Summary
Updates Next.js from 15.4.10 to 15.5.4 in remaining vulnerable templates:
- templates/assistant-ui
- templates/next-image
- templates/next-video-template

## CVEs Addressed
- **CVE-2025-55182**: Node.js-only React Server Components RCE
- **CVE-2025-55183**: Potential Authorization Bypass for RSC Actions
- **CVE-2025-55184**: Potential Authorization Bypass for Server Function

## Test plan
- [ ] Verify Vercel deployments succeed
- [ ] Test template functionality

🤖 Generated with [Claude Code](https://claude.ai/code)