### PR TITLE
feat(server, templates): add Veo 3.1 model support

### DIFF
--- a/packages/app/server/src/clients/veo3-client.ts
+++ b/packages/app/server/src/clients/veo3-client.ts
@@ -16,7 +16,7 @@ async function makeRequest() {
   const prompt = `An anime-style racing scene. A cool looking guy is racing away from villians in a japanese sports car.`;
 
   let operation = await ai.models.generateVideos({
-    model: 'veo-3.0-fast-generate-001',
+    model: 'veo-3.1-fast-generate-001',
     prompt: prompt,
     config: {
       durationSeconds: 4,

--- a/packages/app/server/src/providers/VertexAIProvider.ts
+++ b/packages/app/server/src/providers/VertexAIProvider.ts
@@ -19,6 +19,8 @@ import { env } from '../env';
 // Constants
 export const PROXY_PASSTHROUGH_ONLY_MODEL = 'PROXY_PLACEHOLDER_VERTEX_AI';
 const VEO3_MODELS = [
+  'veo-3.1-fast-generate-preview',
+  'veo-3.1-generate-preview',
   'veo-3.0-fast-generate-preview',
   'veo-3.0-generate-preview',
 ];

--- a/packages/sdk/ts/src/supported-models/video/gemini.ts
+++ b/packages/sdk/ts/src/supported-models/video/gemini.ts
@@ -1,10 +1,24 @@
 import { SupportedVideoModel } from 'supported-models/types';
 
 export type GeminiVideoModel =
+  | 'veo-3.1-generate-001'
+  | 'veo-3.1-fast-generate-001'
   | 'veo-3.0-generate-001'
   | 'veo-3.0-fast-generate-001';
 // https://ai.google.dev/gemini-api/docs/pricing
 export const GeminiVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-generate-001',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'Gemini',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-001',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'Gemini',
+  },
   {
     model_id: 'veo-3.0-generate-001',
     cost_per_second_with_audio: 0.4,

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -1,26 +1,42 @@
 import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 /**
  * Vertex AI video models with official pricing information
  * Based on: https://cloud.google.com/vertex-ai/generative-ai/pricing
  *
+ * Veo 3.1: $0.40/second with audio, $0.20/second video only (same as Veo 3 for 720p/1080p)
+ * Veo 3.1 Fast: $0.15/second with audio, $0.10/second video only (same as Veo 3 Fast for 720p/1080p)
  * Veo 3: $0.40/second with audio, $0.20/second video only
  * Veo 3 Fast: $0.15/second with audio, $0.10/second video only
  */
 export const VertexAIVideoModels: SupportedVideoModel[] = [
   {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
+  {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,
-    cost_per_second_without_audio: 0.1, // Fixed: was 0.1, now 0.10 for clarity
+    cost_per_second_without_audio: 0.1,
     provider: 'VertexAI',
   },
   {
     model_id: 'veo-3.0-generate-preview',
-    cost_per_second_with_audio: 0.4, // Fixed: was 0.4, now 0.40 for clarity
-    cost_per_second_without_audio: 0.2, // Fixed: was 0.2, now 0.20 for clarity
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
     provider: 'VertexAI',
   },
 ];

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,6 +35,8 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
   ];

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -14,7 +14,11 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model:
+    | 'veo-3.1-fast-generate-preview'
+    | 'veo-3.1-generate-preview'
+    | 'veo-3.0-fast-generate-preview'
+    | 'veo-3.0-generate-preview',
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/app/page.tsx
+++ b/templates/next-video-template/src/app/page.tsx
@@ -8,7 +8,7 @@
  *
  * Key features:
  * 1. Authentication: Automatic login/logout with Echo SDK
- * 2. Video Generation: Support for Veo 3 Fast model
+ * 2. Video Generation: Support for Veo 3.1 and Veo 3 models
  * 3. Duration Control: Adjustable video length (1-60 seconds)
  * 4. History: Persistent video gallery with download/copy actions
  * 5. Responsive Design: Works on desktop and mobile
@@ -16,7 +16,7 @@
  * Usage Examples:
  * - Text-to-Video: "A beautiful sunset over mountains with birds flying"
  * - Duration Control: Adjust slider for video length
- * - Model Selection: Currently supports Veo 3 Fast
+ * - Model Selection: Supports Veo 3.1 Fast (default), Veo 3.1, Veo 3 Fast, and Veo 3
  */
 
 import { isSignedIn } from '@/echo';

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,6 +42,8 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1' },
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
 ];
@@ -57,7 +59,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-preview'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,6 +14,8 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 


### PR DESCRIPTION
## Description

Add support for Google's new Veo 3.1 video generation models across the Echo router, SDK, and video template. This resolves #595 by adding both `veo-3.1-generate-preview` and `veo-3.1-fast-generate-preview` as supported models and making them the default in the video template.

## Changes

### Router (packages/app/server)
- Added `veo-3.1-fast-generate-preview` and `veo-3.1-generate-preview` to the `VEO3_MODELS` list in `VertexAIProvider.ts`
- Updated the test client (`veo3-client.ts`) to use the new 3.1 model

### SDK (packages/sdk/ts)
- Added Veo 3.1 models to Vertex AI video model definitions with pricing ($0.40/sec with audio for standard, $0.15/sec for fast — same rate as Veo 3 for 720p/1080p)
- Added Veo 3.1 models to Gemini video model definitions (`veo-3.1-generate-001`, `veo-3.1-fast-generate-001`)
- Updated TypeScript type unions to include the new model IDs

### Template (templates/next-video-template)
- Added Veo 3.1 Fast and Veo 3.1 to the model dropdown in the video generator UI
- Set Veo 3.1 Fast as the new default model
- Updated the API validation to accept the new model strings
- Updated the vertex handler type signature
- Updated page comments to reflect the new model support

## Testing

- Verified all type definitions are consistent across SDK, server, and template
- Validated that existing Veo 3.0 models are preserved for backward compatibility
- Pricing data sourced from Google's official Gemini API pricing page

Fixes #595