### PR TITLE
add veo 3.1 model support

### DIFF
--- a/packages/app/server/src/providers/VertexAIProvider.ts
+++ b/packages/app/server/src/providers/VertexAIProvider.ts
@@ -21,6 +21,8 @@ export const PROXY_PASSTHROUGH_ONLY_MODEL = 'PROXY_PLACEHOLDER_VERTEX_AI';
 const VEO3_MODELS = [
   'veo-3.0-fast-generate-preview',
   'veo-3.0-generate-preview',
+  'veo-3.1-fast-generate-preview',
+  'veo-3.1-generate-preview',
 ];
 const GCS_BUCKET_NAME = 'echo-veo3-videos';
 const GCS_URI_PREFIX = 'gs://';

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -2,7 +2,9 @@ import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
   | 'veo-3.0-fast-generate-preview'
-  | 'veo-3.0-generate-preview';
+  | 'veo-3.0-generate-preview'
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview';
 /**
  * Vertex AI video models with official pricing information
  * Based on: https://cloud.google.com/vertex-ai/generative-ai/pricing
@@ -21,6 +23,18 @@ export const VertexAIVideoModels: SupportedVideoModel[] = [
     model_id: 'veo-3.0-generate-preview',
     cost_per_second_with_audio: 0.4, // Fixed: was 0.4, now 0.40 for clarity
     cost_per_second_without_audio: 0.2, // Fixed: was 0.2, now 0.20 for clarity
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
     provider: 'VertexAI',
   },
 ];

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -37,6 +37,8 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   const validModels: VideoModelOption[] = [
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
   ];
   if (!model || !validModels.includes(model as VideoModelOption)) {
     return {

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -14,7 +14,7 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview' | 'veo-3.1-fast-generate-preview' | 'veo-3.1-generate-preview',
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -44,6 +44,8 @@ import { VideoHistory } from './video-history';
 const models: VideoModelConfig[] = [
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1' },
 ];
 
 /**

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -15,7 +15,9 @@ export type ModelOption = 'openai' | 'gemini';
  */
 export type VideoModelOption =
   | 'veo-3.0-fast-generate-preview'
-  | 'veo-3.0-generate-preview';
+  | 'veo-3.0-generate-preview'
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview';
 
 /**
  * Model configuration with display names


### PR DESCRIPTION
Adds support for the new Google Veo 3.1 models:
- veo-3.1-generate-preview
- veo-3.1-fast-generate-preview

Updated the router and video template.

Closes #595