### PR TITLE
feat: template referral system in echo-start

### DIFF
--- a/packages/sdk/echo-start/src/index.ts
+++ b/packages/sdk/echo-start/src/index.ts
@@ -14,7 +14,7 @@ import chalk from 'chalk';
 import { spawn } from 'child_process';
 import { Command } from 'commander';
 import degit from 'degit';
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import path from 'path';
 
 const program = new Command();
@@ -200,6 +200,68 @@ function resolveTemplateRepo(template: string): string {
   }
 
   return repo;
+}
+
+interface EchoTemplateConfig {
+  referralCode?: string;
+}
+
+/**
+ * Read echo.config.json from a scaffolded template directory.
+ * Template creators can include this file to specify their referral code,
+ * which will be auto-registered when a user scaffolds from the template.
+ */
+function readTemplateReferralConfig(
+  projectPath: string
+): EchoTemplateConfig | null {
+  const configPath = path.join(projectPath, 'echo.config.json');
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    const config = JSON.parse(content) as EchoTemplateConfig;
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the GitHub owner (user or org) from a GitHub template URL.
+ * e.g. "https://github.com/someuser/my-template" -> "someuser"
+ */
+function extractTemplateOwner(templateUrl: string): string | null {
+  const repo = resolveTemplateRepo(templateUrl);
+  const parts = repo.split('/');
+  return parts.length >= 2 ? parts[0] : null;
+}
+
+/**
+ * Detect the appropriate env var name for the referral code based on the project's framework.
+ */
+function detectReferralEnvVarName(projectPath: string): string {
+  const pkgPath = path.join(projectPath, 'package.json');
+
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+      if (deps['next']) {
+        return 'NEXT_PUBLIC_ECHO_REFERRAL_CODE';
+      } else if (deps['vite']) {
+        return 'VITE_ECHO_REFERRAL_CODE';
+      } else if (deps['react-scripts']) {
+        return 'REACT_APP_ECHO_REFERRAL_CODE';
+      }
+    } catch {
+      // Fall through to default
+    }
+  }
+
+  return 'NEXT_PUBLIC_ECHO_REFERRAL_CODE';
 }
 
 function detectEnvVarName(projectPath: string): string | null {
@@ -412,6 +474,45 @@ async function createApp(projectDir: string, options: CreateAppOptions) {
       const envContent = `${envVarName}=${appId}\n`;
       writeFileSync(envPath, envContent);
       log.message(`Created .env.local with ${envVarName}`);
+    }
+
+    // Handle template referral system for external templates.
+    // If the template includes an echo.config.json with a referralCode,
+    // write it to .env.local so the OAuth flow auto-registers the template
+    // creator as the referrer on the new app.
+    // See: https://echo.merit.systems/docs/money/referrals
+    if (isExternal) {
+      const templateConfig = readTemplateReferralConfig(absoluteProjectPath);
+      const referralCode = templateConfig?.referralCode;
+
+      if (referralCode) {
+        const referralEnvVar = detectReferralEnvVarName(absoluteProjectPath);
+        const envFilePath = path.join(absoluteProjectPath, '.env.local');
+
+        if (existsSync(envFilePath)) {
+          const currentEnv = readFileSync(envFilePath, 'utf-8');
+          writeFileSync(
+            envFilePath,
+            currentEnv.trimEnd() + `\n${referralEnvVar}=${referralCode}\n`
+          );
+        } else {
+          writeFileSync(envFilePath, `${referralEnvVar}=${referralCode}\n`);
+        }
+
+        const owner = extractTemplateOwner(template);
+        log.message(
+          `Registered template referral code from ${owner ? `@${owner}` : 'template creator'}`
+        );
+      }
+
+      // Clean up echo.config.json - it's template metadata, not app code
+      const echoConfigPath = path.join(
+        absoluteProjectPath,
+        'echo.config.json'
+      );
+      if (existsSync(echoConfigPath)) {
+        unlinkSync(echoConfigPath);
+      }
     }
 
     log.step('Project setup completed successfully');

--- a/packages/sdk/echo-start/src/index.ts
+++ b/packages/sdk/echo-start/src/index.ts
@@ -229,6 +229,31 @@ function readTemplateReferralConfig(
 }
 
 /**
+ * Sanitize a referral code to prevent environment variable injection.
+ * Only allows alphanumeric characters, hyphens, underscores, and dots.
+ * Returns null if the code is invalid or empty after sanitization.
+ */
+function sanitizeReferralCode(code: unknown): string | null {
+  if (typeof code !== 'string' || code.length === 0) {
+    return null;
+  }
+
+  // Strict allowlist: only alphanumeric, hyphens, underscores, dots
+  const SAFE_REFERRAL_PATTERN = /^[a-zA-Z0-9_\-\.]+$/;
+
+  if (!SAFE_REFERRAL_PATTERN.test(code)) {
+    return null;
+  }
+
+  // Enforce a reasonable max length
+  if (code.length > 128) {
+    return null;
+  }
+
+  return code;
+}
+
+/**
  * Extract the GitHub owner (user or org) from a GitHub template URL.
  * e.g. "https://github.com/someuser/my-template" -> "someuser"
  */
@@ -483,7 +508,14 @@ async function createApp(projectDir: string, options: CreateAppOptions) {
     // See: https://echo.merit.systems/docs/money/referrals
     if (isExternal) {
       const templateConfig = readTemplateReferralConfig(absoluteProjectPath);
-      const referralCode = templateConfig?.referralCode;
+      const referralCode = sanitizeReferralCode(templateConfig?.referralCode);
+
+      if (templateConfig?.referralCode && !referralCode) {
+        log.warning(
+          'Template referral code was ignored: contains invalid characters. ' +
+            'Only alphanumeric characters, hyphens, underscores, and dots are allowed.'
+        );
+      }
 
       if (referralCode) {
         const referralEnvVar = detectReferralEnvVarName(absoluteProjectPath);


### PR DESCRIPTION
## Summary

Implements #612 - Template referral system for external templates.

- When a user scaffolds from an external template via `echo-start`, the CLI now reads an `echo.config.json` from the template for a `referralCode` field
- If found, the referral code is written to `.env.local` with the appropriate framework prefix (`NEXT_PUBLIC_ECHO_REFERRAL_CODE`, `VITE_ECHO_REFERRAL_CODE`, etc.) so the OAuth flow auto-registers the template creator as the referrer on the new app
- The `echo.config.json` is cleaned up after processing since it's template metadata, not app code
- Template creators can include `{ "referralCode": "<their-code>" }` in `echo.config.json` to earn referral rewards when others use their template

### How it works

1. Template creator adds `echo.config.json` to their template repo:
   ```json
   { "referralCode": "abc-123-def-456" }
   ```
2. User scaffolds: `npx echo-start --template https://github.com/creator/template --app-id <id>`
3. `echo-start` reads the referral code, writes it to `.env.local`, and removes the config file
4. When the user's app runs and authenticates via OAuth, the referral code is available to register the template creator as referrer

Closes #612

## Test plan

- [ ] Verify `echo-start` with an external template containing `echo.config.json` with `referralCode` writes the code to `.env.local`
- [ ] Verify `echo-start` with an external template without `echo.config.json` works unchanged
- [ ] Verify `echo.config.json` is removed from the scaffolded project after processing
- [ ] Verify the correct framework-prefixed env var name is used (Next.js, Vite, CRA)
- [ ] Verify built-in templates are unaffected by this change