### PR TITLE
feat: add Veo 3.1 video model support

### DIFF
--- a/packages/app/server/src/clients/veo3-client.ts
+++ b/packages/app/server/src/clients/veo3-client.ts
@@ -16,7 +16,7 @@ async function makeRequest() {
   const prompt = `An anime-style racing scene. A cool looking guy is racing away from villians in a japanese sports car.`;
 
   let operation = await ai.models.generateVideos({
-    model: 'veo-3.0-fast-generate-001',
+    model: 'veo-3.1-fast-generate-001',
     prompt: prompt,
     config: {
       durationSeconds: 4,

--- a/packages/app/server/src/providers/VertexAIProvider.ts
+++ b/packages/app/server/src/providers/VertexAIProvider.ts
@@ -19,6 +19,8 @@ import { env } from '../env';
 // Constants
 export const PROXY_PASSTHROUGH_ONLY_MODEL = 'PROXY_PLACEHOLDER_VERTEX_AI';
 const VEO3_MODELS = [
+  'veo-3.1-fast-generate-preview',
+  'veo-3.1-generate-preview',
   'veo-3.0-fast-generate-preview',
   'veo-3.0-generate-preview',
 ];

--- a/packages/sdk/ts/src/supported-models/video/gemini.ts
+++ b/packages/sdk/ts/src/supported-models/video/gemini.ts
@@ -2,9 +2,23 @@ import { SupportedVideoModel } from 'supported-models/types';
 
 export type GeminiVideoModel =
   | 'veo-3.0-generate-001'
-  | 'veo-3.0-fast-generate-001';
+  | 'veo-3.0-fast-generate-001'
+  | 'veo-3.1-generate-001'
+  | 'veo-3.1-fast-generate-001';
 // https://ai.google.dev/gemini-api/docs/pricing
 export const GeminiVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-generate-001',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'Gemini',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-001',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'Gemini',
+  },
   {
     model_id: 'veo-3.0-generate-001',
     cost_per_second_with_audio: 0.4,

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -2,25 +2,39 @@ import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
   | 'veo-3.0-fast-generate-preview'
-  | 'veo-3.0-generate-preview';
+  | 'veo-3.0-generate-preview'
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview';
 /**
  * Vertex AI video models with official pricing information
  * Based on: https://cloud.google.com/vertex-ai/generative-ai/pricing
  *
- * Veo 3: $0.40/second with audio, $0.20/second video only
- * Veo 3 Fast: $0.15/second with audio, $0.10/second video only
+ * Veo 3.x: $0.40/second with audio, $0.20/second video only
+ * Veo 3.x Fast: $0.15/second with audio, $0.10/second video only
  */
 export const VertexAIVideoModels: SupportedVideoModel[] = [
   {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
+  {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,
-    cost_per_second_without_audio: 0.1, // Fixed: was 0.1, now 0.10 for clarity
+    cost_per_second_without_audio: 0.1,
     provider: 'VertexAI',
   },
   {
     model_id: 'veo-3.0-generate-preview',
-    cost_per_second_with_audio: 0.4, // Fixed: was 0.4, now 0.40 for clarity
-    cost_per_second_without_audio: 0.2, // Fixed: was 0.2, now 0.20 for clarity
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
     provider: 'VertexAI',
   },
 ];

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,6 +35,8 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
   ];

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -14,7 +14,11 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model:
+    | 'veo-3.1-fast-generate-preview'
+    | 'veo-3.1-generate-preview'
+    | 'veo-3.0-fast-generate-preview'
+    | 'veo-3.0-generate-preview',
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,6 +42,8 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1' },
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
 ];
@@ -57,7 +59,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-preview'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,6 +14,8 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 


### PR DESCRIPTION
Resolves #595

## Summary

Add support for Google Vertex AI Veo 3.1 video models (`veo-3.1-generate-preview` and `veo-3.1-fast-generate-preview`) to the Echo router and Next.js video template, as announced in [Google's Vertex AI documentation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-1-generate-preview).

## Changes

### Router (SDK + Server)
- **`packages/sdk/ts/src/supported-models/video/vertex-ai.ts`** — Add `veo-3.1-generate-preview` and `veo-3.1-fast-generate-preview` type unions and model entries with pricing ($0.40/s standard, $0.15/s fast)
- **`packages/sdk/ts/src/supported-models/video/gemini.ts`** — Add `veo-3.1-generate-001` and `veo-3.1-fast-generate-001` type unions and model entries
- **`packages/app/server/src/providers/VertexAIProvider.ts`** — Add Veo 3.1 models to `VEO3_MODELS` constant for GCS URI handling

### Template
- **`templates/next-video-template/src/lib/types.ts`** — Add Veo 3.1 to `VideoModelOption` type union
- **`templates/next-video-template/src/components/video-generator.tsx`** — Add Veo 3.1 model options to UI, set Veo 3.1 Fast as the new default
- **`templates/next-video-template/src/app/api/generate-video/validation.ts`** — Add Veo 3.1 models to valid model list
- **`templates/next-video-template/src/app/api/generate-video/vertex.ts`** — Add Veo 3.1 to model type signature

### Client
- **`packages/app/server/src/clients/veo3-client.ts`** — Update test client to use `veo-3.1-fast-generate-001`

## Notes

- Veo 3.0 models are retained for backward compatibility
- Pricing for Veo 3.1 matches Veo 3.0 ($0.40/s with audio, $0.15/s fast with audio)
- Veo 3.1 is set as the new default in the video template
- No architectural changes needed — the existing model-to-provider mapping handles new models automatically

**AI disclosure:** This PR was implemented with AI assistance using Claude Code (Anthropic).