### PR TITLE
Fix #636: Add .cursor/rules/echo_rules.mdc to echo-start templates

### DIFF
--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + Next.js starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js rules
+
+- Use `@merit-systems/echo-next-sdk` as the source of truth for Echo integration.
+- Keep Echo server setup in the template's Echo module (for example `src/echo/index.ts` or `echo.ts`) instead of scattering initialization logic.
+- Read app IDs from environment variables only, following the existing template pattern (`ECHO_APP_ID` and/or `NEXT_PUBLIC_ECHO_APP_ID`).
+- Keep the Echo webhook route as a thin passthrough that re-exports handlers (`export const { GET, POST } = handlers`).
+- Wrap client-side UI that needs Echo auth, balance, or sign-in with `EchoProvider` from `@merit-systems/echo-next-sdk/client`.
+- Reuse model helpers exported by the Echo module (`openai`, `anthropic`, `google` when present) instead of creating ad-hoc provider clients.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + Auth.js starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Auth.js rules
+
+- Keep authentication wired through `next-auth` with `@merit-systems/echo-authjs-provider`.
+- Configure Echo Auth.js provider with `appId: process.env.ECHO_APP_ID!` and do not hardcode IDs.
+- Preserve the NextAuth handler export shape (`export const { handlers, signIn, signOut, auth } = NextAuth(...)`).
+- Keep `/api/auth/[...nextauth]` and `/api/echo/[...echo]` routes as thin re-exports from their respective handler modules.
+- Keep JWT/session callbacks aligned with existing access token + refresh token behavior unless a migration explicitly changes auth storage.
+- Use `@merit-systems/echo-next-sdk` for Echo route handlers and server model access in this template.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo CLI starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo CLI rules
+
+- Keep CLI command wiring in `src/index.ts` and business logic in `src/auth`, `src/core`, `src/config`, and `src/utils` modules.
+- Use `process.env.ECHO_APP_ID` (via `src/constants.ts`) as the Echo app identifier; do not hardcode app IDs.
+- Keep provider selection centralized in `src/auth/providers.ts` (`echo`, `wallet`, `local-wallet`).
+- Use `createEchoOpenAI` for API-key auth and `createX402OpenAI` for wallet-based auth exactly through existing helper flow.
+- Keep streaming chat behavior built on AI SDK `streamText` and existing terminal stream helpers.
+- Preserve history/thread persistence and auth state checks before sending model requests.
+- Never print or store private keys, API keys, or tokens outside the existing secure storage utilities.

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + Next.js starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js rules
+
+- Use `@merit-systems/echo-next-sdk` as the source of truth for Echo integration.
+- Keep Echo server setup in the template's Echo module (for example `src/echo/index.ts` or `echo.ts`) instead of scattering initialization logic.
+- Read app IDs from environment variables only, following the existing template pattern (`ECHO_APP_ID` and/or `NEXT_PUBLIC_ECHO_APP_ID`).
+- Keep the Echo webhook route as a thin passthrough that re-exports handlers (`export const { GET, POST } = handlers`).
+- Wrap client-side UI that needs Echo auth, balance, or sign-in with `EchoProvider` from `@merit-systems/echo-next-sdk/client`.
+- Reuse model helpers exported by the Echo module (`openai`, `anthropic`, `google` when present) instead of creating ad-hoc provider clients.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + Next.js starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js rules
+
+- Use `@merit-systems/echo-next-sdk` as the source of truth for Echo integration.
+- Keep Echo server setup in the template's Echo module (for example `src/echo/index.ts` or `echo.ts`) instead of scattering initialization logic.
+- Read app IDs from environment variables only, following the existing template pattern (`ECHO_APP_ID` and/or `NEXT_PUBLIC_ECHO_APP_ID`).
+- Keep the Echo webhook route as a thin passthrough that re-exports handlers (`export const { GET, POST } = handlers`).
+- Wrap client-side UI that needs Echo auth, balance, or sign-in with `EchoProvider` from `@merit-systems/echo-next-sdk/client`.
+- Reuse model helpers exported by the Echo module (`openai`, `anthropic`, `google` when present) instead of creating ad-hoc provider clients.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + Next.js starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js rules
+
+- Use `@merit-systems/echo-next-sdk` as the source of truth for Echo integration.
+- Keep Echo server setup in the template's Echo module (for example `src/echo/index.ts` or `echo.ts`) instead of scattering initialization logic.
+- Read app IDs from environment variables only, following the existing template pattern (`ECHO_APP_ID` and/or `NEXT_PUBLIC_ECHO_APP_ID`).
+- Keep the Echo webhook route as a thin passthrough that re-exports handlers (`export const { GET, POST } = handlers`).
+- Wrap client-side UI that needs Echo auth, balance, or sign-in with `EchoProvider` from `@merit-systems/echo-next-sdk/client`.
+- Reuse model helpers exported by the Echo module (`openai`, `anthropic`, `google` when present) instead of creating ad-hoc provider clients.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + Next.js starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js rules
+
+- Use `@merit-systems/echo-next-sdk` as the source of truth for Echo integration.
+- Keep Echo server setup in the template's Echo module (for example `src/echo/index.ts` or `echo.ts`) instead of scattering initialization logic.
+- Read app IDs from environment variables only, following the existing template pattern (`ECHO_APP_ID` and/or `NEXT_PUBLIC_ECHO_APP_ID`).
+- Keep the Echo webhook route as a thin passthrough that re-exports handlers (`export const { GET, POST } = handlers`).
+- Wrap client-side UI that needs Echo auth, balance, or sign-in with `EchoProvider` from `@merit-systems/echo-next-sdk/client`.
+- Reuse model helpers exported by the Echo module (`openai`, `anthropic`, `google` when present) instead of creating ad-hoc provider clients.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + Next.js starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js rules
+
+- Use `@merit-systems/echo-next-sdk` as the source of truth for Echo integration.
+- Keep Echo server setup in the template's Echo module (for example `src/echo/index.ts` or `echo.ts`) instead of scattering initialization logic.
+- Read app IDs from environment variables only, following the existing template pattern (`ECHO_APP_ID` and/or `NEXT_PUBLIC_ECHO_APP_ID`).
+- Keep the Echo webhook route as a thin passthrough that re-exports handlers (`export const { GET, POST } = handlers`).
+- Wrap client-side UI that needs Echo auth, balance, or sign-in with `EchoProvider` from `@merit-systems/echo-next-sdk/client`.
+- Reuse model helpers exported by the Echo module (`openai`, `anthropic`, `google` when present) instead of creating ad-hoc provider clients.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + React/Vite starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo React rules
+
+- Use `@merit-systems/echo-react-sdk` for Echo integration in React templates.
+- Keep `EchoProvider` at the root app boundary (`main.tsx` or `App.tsx`) so all Echo hooks/components share one provider.
+- Use `import.meta.env.VITE_ECHO_APP_ID` for app configuration; do not introduce server-only secret env vars into client code.
+- Prefer existing Echo hooks and components (`useEcho`, `useEchoModelProviders`, `EchoTokens`, `EchoChatProvider`) over reimplementing auth or balance flows.
+- When streaming chat responses, keep using AI SDK utilities already used in the template (`streamText`, `convertToModelMessages`) unless there is a clear reason to change.
+- Keep Echo auth/payment logic in the Echo SDK layer; avoid custom token handling in the browser.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + React/Vite starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo React rules
+
+- Use `@merit-systems/echo-react-sdk` for Echo integration in React templates.
+- Keep `EchoProvider` at the root app boundary (`main.tsx` or `App.tsx`) so all Echo hooks/components share one provider.
+- Use `import.meta.env.VITE_ECHO_APP_ID` for app configuration; do not introduce server-only secret env vars into client code.
+- Prefer existing Echo hooks and components (`useEcho`, `useEchoModelProviders`, `EchoTokens`, `EchoChatProvider`) over reimplementing auth or balance flows.
+- When streaming chat responses, keep using AI SDK utilities already used in the template (`streamText`, `convertToModelMessages`) unless there is a clear reason to change.
+- Keep Echo auth/payment logic in the Echo SDK layer; avoid custom token handling in the browser.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Echo + React/Vite starter rules for this template
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo React rules
+
+- Use `@merit-systems/echo-react-sdk` for Echo integration in React templates.
+- Keep `EchoProvider` at the root app boundary (`main.tsx` or `App.tsx`) so all Echo hooks/components share one provider.
+- Use `import.meta.env.VITE_ECHO_APP_ID` for app configuration; do not introduce server-only secret env vars into client code.
+- Prefer existing Echo hooks and components (`useEcho`, `useEchoModelProviders`, `EchoTokens`, `EchoChatProvider`) over reimplementing auth or balance flows.
+- When streaming chat responses, keep using AI SDK utilities already used in the template (`streamText`, `convertToModelMessages`) unless there is a clear reason to change.
+- Keep Echo auth/payment logic in the Echo SDK layer; avoid custom token handling in the browser.
+- Never hardcode Echo app IDs, API keys, wallet keys, or test secrets in source files.


### PR DESCRIPTION
## Summary

This PR resolves #636.

### Changes

Added framework-tailored Cursor rules files (.cursor/rules/echo_rules.mdc) to every echo-start template (Next.js family, React/Vite family, and Echo CLI) with guidance aligned to each template's actual Echo integration patterns.

### Files Modified

- `templates/assistant-ui/.cursor/rules/echo_rules.mdc`
- `templates/authjs/.cursor/rules/echo_rules.mdc`
- `templates/echo-cli/.cursor/rules/echo_rules.mdc`
- `templates/next/.cursor/rules/echo_rules.mdc`
- `templates/next-chat/.cursor/rules/echo_rules.mdc`
- `templates/next-image/.cursor/rules/echo_rules.mdc`
- `templates/next-video-template/.cursor/rules/echo_rules.mdc`
- `templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc`
- `templates/react/.cursor/rules/echo_rules.mdc`
- `templates/react-chat/.cursor/rules/echo_rules.mdc`
- `templates/react-image/.cursor/rules/echo_rules.mdc`
- `DONE.json`

Happy to address any feedback or make adjustments.

/claim #636