### PR TITLE
Fix #634: Handle Gemini Deprecation

### DIFF
--- a/packages/sdk/ts/scripts/update-gemini-models.ts
+++ b/packages/sdk/ts/scripts/update-gemini-models.ts
@@ -20,6 +20,11 @@ interface GeminiApiResponse {
   models: GeminiApiModel[];
 }
 
+const RETIRED_GEMINI_MODELS = new Set([
+  'gemini-2.0-flash-preview-image-generation',
+  'gemini-2.5-flash-image-preview',
+]);
+
 async function fetchGeminiModels(): Promise<string[]> {
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) {
@@ -68,7 +73,8 @@ async function fetchGeminiModels(): Promise<string[]> {
         // Extract model ID from the full name (e.g., "models/gemini-pro" -> "gemini-pro")
         const modelId = model.name.replace('models/', '');
         return modelId;
-      });
+      })
+      .filter(modelId => !RETIRED_GEMINI_MODELS.has(modelId));
 
     console.log(`📝 Filtered to ${modelIds.length} language models:`);
     modelIds.forEach(id => console.log(`  - ${id}`));

--- a/packages/sdk/ts/src/supported-models/chat/gemini.ts
+++ b/packages/sdk/ts/src/supported-models/chat/gemini.ts
@@ -10,13 +10,11 @@ export type GeminiModel =
   | 'gemini-2.0-flash-lite-001'
   | 'gemini-2.0-flash-lite-preview'
   | 'gemini-2.0-flash-lite-preview-02-05'
-  | 'gemini-2.0-flash-preview-image-generation'
   | 'gemini-2.0-flash-thinking-exp'
   | 'gemini-2.0-flash-thinking-exp-01-21'
   | 'gemini-2.0-flash-thinking-exp-1219'
   | 'gemini-2.5-flash'
   | 'gemini-2.5-flash-image'
-  | 'gemini-2.5-flash-image-preview'
   | 'gemini-2.5-flash-lite'
   | 'gemini-2.5-flash-lite-preview-06-17'
   | 'gemini-2.5-flash-lite-preview-09-2025'
@@ -79,12 +77,6 @@ export const GeminiModels: SupportedModel[] = [
     provider: 'Gemini',
   },
   {
-    model_id: 'gemini-2.0-flash-preview-image-generation',
-    input_cost_per_token: 1e-7,
-    output_cost_per_token: 4e-7,
-    provider: 'Gemini',
-  },
-  {
     model_id: 'gemini-2.0-flash-thinking-exp',
     input_cost_per_token: 1e-7,
     output_cost_per_token: 4e-7,
@@ -110,12 +102,6 @@ export const GeminiModels: SupportedModel[] = [
   },
   {
     model_id: 'gemini-2.5-flash-image',
-    input_cost_per_token: 3e-7,
-    output_cost_per_token: 0.0000025,
-    provider: 'Gemini',
-  },
-  {
-    model_id: 'gemini-2.5-flash-image-preview',
     input_cost_per_token: 3e-7,
     output_cost_per_token: 0.0000025,
     provider: 'Gemini',

--- a/packages/tests/provider-smoke/gemini-generate-text.test.ts
+++ b/packages/tests/provider-smoke/gemini-generate-text.test.ts
@@ -15,7 +15,6 @@ import {
 beforeAll(assertEnv);
 
 export const BLACKLISTED_MODELS = new Set([
-  'gemini-2.0-flash-preview-image-generation',
   'veo-3.0-fast-generate',
   'gemini-2.0-flash-exp',
   'gemini-2.0-flash-thinking-exp-1219',

--- a/templates/next-image/src/app/api/edit-image/google.ts
+++ b/templates/next-image/src/app/api/edit-image/google.ts
@@ -28,7 +28,7 @@ export async function handleGoogleEdit(
     ];
 
     const result = await generateText({
-      model: google('gemini-2.5-flash-image-preview'),
+      model: google('gemini-2.5-flash-image'),
       prompt: [
         {
           role: 'user',

--- a/templates/next-image/src/app/api/generate-image/google.ts
+++ b/templates/next-image/src/app/api/generate-image/google.ts
@@ -12,7 +12,7 @@ import { ERROR_MESSAGES } from '@/lib/constants';
 export async function handleGoogleGenerate(prompt: string): Promise<Response> {
   try {
     const result = await generateText({
-      model: google('gemini-2.5-flash-image-preview'),
+      model: google('gemini-2.5-flash-image'),
       prompt,
     });
 


### PR DESCRIPTION
## Summary

This PR resolves #634.

### Changes

Removed retired Gemini models from the TypeScript SDK model registry/type, which also updates router model validation via AccountingService, and updated Next image template Gemini calls to use gemini-2.5-flash-image. Also removed obsolete smoke-test blacklist entry.

### Files Modified

- `packages/sdk/ts/src/supported-models/chat/gemini.ts`
- `templates/next-image/src/app/api/generate-image/google.ts`
- `templates/next-image/src/app/api/edit-image/google.ts`
- `packages/tests/provider-smoke/gemini-generate-text.test.ts`
- `DONE.json`

Happy to address any feedback or make adjustments.

/claim #634