### PR TITLE
feat(veo): add Veo 3.1 model support

### DIFF
--- a/packages/app/server/src/providers/VertexAIProvider.ts
+++ b/packages/app/server/src/providers/VertexAIProvider.ts
@@ -18,9 +18,11 @@ import { env } from '../env';
 
 // Constants
 export const PROXY_PASSTHROUGH_ONLY_MODEL = 'PROXY_PLACEHOLDER_VERTEX_AI';
-const VEO3_MODELS = [
+const VEO_MODELS = [
   'veo-3.0-fast-generate-preview',
   'veo-3.0-generate-preview',
+  'veo-3.1-generate-preview',
+  'veo-3.1-fast-generate-preview',
 ];
 const GCS_BUCKET_NAME = 'echo-veo3-videos';
 const GCS_URI_PREFIX = 'gs://';
@@ -496,7 +498,7 @@ export class VertexAIProvider extends BaseProvider {
     }
   }
 
-  private isVeo3Model(): boolean {
-    return VEO3_MODELS.includes(this.getModel());
+  private isVeoModel(): boolean {
+    return VEO_MODELS.includes(this.getModel());
   }
 }

--- a/packages/sdk/ts/src/supported-models/video/gemini.ts
+++ b/packages/sdk/ts/src/supported-models/video/gemini.ts
@@ -2,9 +2,23 @@ import { SupportedVideoModel } from 'supported-models/types';
 
 export type GeminiVideoModel =
   | 'veo-3.0-generate-001'
-  | 'veo-3.0-fast-generate-001';
+  | 'veo-3.0-fast-generate-001'
+  | 'veo-3.1-generate-preview'
+  | 'veo-3.1-fast-generate-preview';
 // https://ai.google.dev/gemini-api/docs/pricing
 export const GeminiVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'Gemini',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'Gemini',
+  },
   {
     model_id: 'veo-3.0-generate-001',
     cost_per_second_with_audio: 0.4,

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -2,25 +2,41 @@ import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
   | 'veo-3.0-fast-generate-preview'
-  | 'veo-3.0-generate-preview';
+  | 'veo-3.0-generate-preview'
+  | 'veo-3.1-generate-preview'
+  | 'veo-3.1-fast-generate-preview';
 /**
  * Vertex AI video models with official pricing information
  * Based on: https://cloud.google.com/vertex-ai/generative-ai/pricing
  *
- * Veo 3: $0.40/second with audio, $0.20/second video only
- * Veo 3 Fast: $0.15/second with audio, $0.10/second video only
+ * Veo 3.0: $0.40/second with audio, $0.20/second video only
+ * Veo 3.0 Fast: $0.15/second with audio, $0.10/second video only
+ * Veo 3.1: $0.40/second with audio, $0.20/second video only
+ * Veo 3.1 Fast: $0.15/second with audio, $0.10/second video only
  */
 export const VertexAIVideoModels: SupportedVideoModel[] = [
   {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,
-    cost_per_second_without_audio: 0.1, // Fixed: was 0.1, now 0.10 for clarity
+    cost_per_second_without_audio: 0.1,
     provider: 'VertexAI',
   },
   {
     model_id: 'veo-3.0-generate-preview',
-    cost_per_second_with_audio: 0.4, // Fixed: was 0.4, now 0.40 for clarity
-    cost_per_second_without_audio: 0.2, // Fixed: was 0.2, now 0.20 for clarity
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
     provider: 'VertexAI',
   },
 ];

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,6 +35,8 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
+    'veo-3.1-generate-preview',
+    'veo-3.1-fast-generate-preview',
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
   ];

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -4,6 +4,7 @@
 
 import { getEchoToken } from '@/echo';
 import { ERROR_MESSAGES } from '@/lib/constants';
+import { VideoModelOption } from '@/lib/types';
 import {
   GenerateVideosOperation,
   GenerateVideosParameters,
@@ -14,7 +15,7 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model: VideoModelOption,
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,6 +42,8 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1' },
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast' },
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
 ];
@@ -57,7 +59,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-preview'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,6 +14,8 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
+  | 'veo-3.1-generate-preview'
+  | 'veo-3.1-fast-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 


### PR DESCRIPTION
Adds support for Veo 3.1 models in the Vertex AI veo provider.

## Changes

- Added `veo-3.1-generate-preview` and `veo-3.1-fast-generate-preview` to `VertexAIVideoModels` with pricing
- Updated `VertexAIVideoModel` type union to include both new Veo 3.1 models
- Added Veo 3.1 models to the `VEO_MODELS` list in `VertexAIProvider` (renamed from `VEO3_MODELS` for future-proofing; likewise `isVeoModel` replaces `isVeo3Model`)
- Updated `VideoModelOption` type in the Next.js template to include Veo 3.1 variants
- Updated request validation to accept Veo 3.1 model IDs
- Updated `handleGeminiGenerate` function signature to accept Veo 3.1 models
- Added Veo 3.1 models to the video generator component model list
- Set `veo-3.1-fast-generate-preview` as the default model in the Next.js video template

## Pricing

Veo 3.1 pricing matches Veo 3.0 (per [Vertex AI pricing docs](https://cloud.google.com/vertex-ai/generative-ai/pricing)):
- `veo-3.1-generate-preview`: $0.40/second with audio, $0.20/second without audio
- `veo-3.1-fast-generate-preview`: $0.15/second with audio, $0.10/second without audio

Closes #595