### PR TITLE
feat(templates): add .cursor/rules/echo_rules.mdc to echo-start

### DIFF
--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,43 +1,28 @@
 ---
-description: Echo assistant-ui template rules covering Echo handler setup, App Router echo route, NEXT_PUBLIC vs server env vars, client-side provider config, and component conventions
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered chat applications with assistant-ui, AI SDK v5, and the assistant-ui React component library
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ---
 
-# Echo assistant-ui Template Rules
+# Echo Assistant-UI Guidelines
 
-## Echo Server Wiring
+## SDK Setup
+- Server-side: Initialize in `src/echo/index.ts` with `@merit-systems/echo-next-sdk`
+- Client-side: Wrap app with `EchoProvider` from `@merit-systems/echo-next-sdk/client`
 
-- Echo is initialized in the root `echo.ts` file (not `src/echo/index.ts` — this template uses `echo.ts` at the project root).
-- The `echo.ts` default export is `echo.handlers`; named exports include `getUser`, `isSignedIn`, `openai`, `anthropic`, `google`.
-- The echo route (typically `app/api/echo/[...path]/route.ts` or `app/api/echo/[...echo]/route.ts`) must stay as a thin passthrough — import `handlers` from `@/echo` (the root `echo.ts`) and export `{ GET, POST }`.
-- Do not move or rename `echo.ts`; the assistant-ui components and API routes depend on its location.
+## Assistant-UI Integration
+
+### Runtime Provider
+- Use `AssistantRuntimeProvider` and `useEdgeRuntime` from `@assistant-ui/react`
+- Use `@assistant-ui/react-markdown` for rendering markdown in messages
+- Use `@assistant-ui/react-ai-sdk` for AI SDK v5 integration
+
+### Chat Components
+- Use `@assistant-ui/react` primitives: `Thread`, `ThreadWelcome`, `Composer`, `AssistantMessage`, `UserMessage`
+
+### Streaming API Route
+- Use `streamText` from `ai` with Echo-proxied models
+- Import models from `@/echo`, not directly from `@ai-sdk/openai`
 
 ## Environment Variables
-
-- This template uses `NEXT_PUBLIC_ECHO_APP_ID` (not `ECHO_APP_ID`) for the Echo `appId`; this is intentional for the assistant-ui client-side provider.
-- Validate that `NEXT_PUBLIC_ECHO_APP_ID` is set before rendering the assistant UI; show a clear setup error if missing.
-- Never add server-only secrets to `NEXT_PUBLIC_` env vars; only the Echo app ID is safe to expose here.
-
-## assistant-ui Component Conventions
-
-- Keep assistant-ui component wiring (`<Thread>`, `<AssistantModal>`, providers) in the designated layout or page component; do not scatter provider setup across multiple files.
-- Use assistant-ui's built-in primitives for message rendering, input handling, and tool call display; avoid building custom replacements unless the template pattern requires it.
-- Pass the Echo-configured model (from `openai`, `anthropic`, or `google`) to the assistant runtime; do not configure model providers independently of Echo.
-
-## Client vs. Server
-
-- Keep `echo.ts` as server-only; import it only from Route Handlers and Server Components.
-- In Client Components, use the assistant-ui hooks and context rather than importing from `echo.ts` directly.
-- Use `@/` path alias for all internal imports.
-
-## App Router Conventions
-
-- Follow Next.js App Router structure with `page.tsx`, `layout.tsx`, `route.ts` conventions.
-- Default to Server Components; use `"use client"` only for assistant-ui interactive components.
-- Preserve the existing component structure in `app/` and `components/`; use the `lib/` folder for shared utilities.
-
-## Security
-
-- Route all model inference through the Echo server handler; the client receives streamed output, never raw API responses.
-- Use `isSignedIn` from `echo.ts` to gate any routes that require an authenticated Echo session.
-- Do not log or return `getUser()` data in client-visible error responses.
+- `ECHO_APP_ID` — Server-side Echo identifier
+- `NEXT_PUBLIC_ECHO_APP_ID` — Client-side Echo identifier

--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,43 @@
+---
+description: Echo assistant-ui template rules covering Echo handler setup, App Router echo route, NEXT_PUBLIC vs server env vars, client-side provider config, and component conventions
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo assistant-ui Template Rules
+
+## Echo Server Wiring
+
+- Echo is initialized in the root `echo.ts` file (not `src/echo/index.ts` — this template uses `echo.ts` at the project root).
+- The `echo.ts` default export is `echo.handlers`; named exports include `getUser`, `isSignedIn`, `openai`, `anthropic`, `google`.
+- The echo route (typically `app/api/echo/[...path]/route.ts` or `app/api/echo/[...echo]/route.ts`) must stay as a thin passthrough — import `handlers` from `@/echo` (the root `echo.ts`) and export `{ GET, POST }`.
+- Do not move or rename `echo.ts`; the assistant-ui components and API routes depend on its location.
+
+## Environment Variables
+
+- This template uses `NEXT_PUBLIC_ECHO_APP_ID` (not `ECHO_APP_ID`) for the Echo `appId`; this is intentional for the assistant-ui client-side provider.
+- Validate that `NEXT_PUBLIC_ECHO_APP_ID` is set before rendering the assistant UI; show a clear setup error if missing.
+- Never add server-only secrets to `NEXT_PUBLIC_` env vars; only the Echo app ID is safe to expose here.
+
+## assistant-ui Component Conventions
+
+- Keep assistant-ui component wiring (`<Thread>`, `<AssistantModal>`, providers) in the designated layout or page component; do not scatter provider setup across multiple files.
+- Use assistant-ui's built-in primitives for message rendering, input handling, and tool call display; avoid building custom replacements unless the template pattern requires it.
+- Pass the Echo-configured model (from `openai`, `anthropic`, or `google`) to the assistant runtime; do not configure model providers independently of Echo.
+
+## Client vs. Server
+
+- Keep `echo.ts` as server-only; import it only from Route Handlers and Server Components.
+- In Client Components, use the assistant-ui hooks and context rather than importing from `echo.ts` directly.
+- Use `@/` path alias for all internal imports.
+
+## App Router Conventions
+
+- Follow Next.js App Router structure with `page.tsx`, `layout.tsx`, `route.ts` conventions.
+- Default to Server Components; use `"use client"` only for assistant-ui interactive components.
+- Preserve the existing component structure in `app/` and `components/`; use the `lib/` folder for shared utilities.
+
+## Security
+
+- Route all model inference through the Echo server handler; the client receives streamed output, never raw API responses.
+- Use `isSignedIn` from `echo.ts` to gate any routes that require an authenticated Echo session.
+- Do not log or return `getUser()` data in client-visible error responses.

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,46 +1,24 @@
 ---
-description: Echo Next.js + Auth.js template rules covering Echo server wiring, Auth.js session handling, protected routes, client providers, and env safety
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered Next.js applications with Auth.js (NextAuth v5) authentication, including provider setup and session management
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ---
 
-# Echo Next.js + Auth.js Template Rules
+# Echo Auth.js Integration Guidelines
 
-## Echo Server Wiring
+## SDK Setup
+- Server-side: Initialize Echo in `src/echo/index.ts` with `@merit-systems/echo-next-sdk`
+- Auth: Configure Auth.js with the Echo provider
 
-- Keep Echo server setup centralized in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `openai`, `anthropic` from there.
-- The echo route (`src/app/api/echo/[...echo]/route.ts`) must stay as a thin passthrough: `export const { GET, POST } = handlers`.
-- Import from `@merit-systems/echo-next-sdk` in server code; use `@merit-systems/echo-next-sdk/client` in Client Components only.
+## Auth.js Configuration
+- Use `EchoProvider` from `@merit-systems/echo-authjs-provider`
+- Mount Auth.js handlers at `src/app/api/auth/[...nextauth]/route.ts`
+- Server components: `const session = await auth()`
+- Client components: Use `useSession()` from `next-auth/react`
 
-## Auth.js Integration
-
-- Define your Auth.js config in `src/auth.ts` (or `src/auth/index.ts`); export `auth`, `signIn`, `signOut`, and `handlers` from there.
-- Protect server routes and Server Components using the `auth()` helper — check `session.user` before proceeding.
-- Use `isSignedIn` from Echo (`src/echo/index.ts`) to additionally gate Echo-specific API usage; combine with Auth.js session checks when both are required.
-- Keep Auth.js providers, callbacks, and adapter config within the auth config file; do not scatter them across API routes.
-- For the Auth.js route, use `src/app/api/auth/[...nextauth]/route.ts` as a passthrough: `export const { GET, POST } = handlers`.
+## Echo TypeScript SDK
+- Use `@merit-systems/echo-typescript-sdk` for server-side Echo API calls
 
 ## Environment Variables
-
-- `ECHO_APP_ID` — server-side Echo app identifier (never expose to client).
-- `NEXTAUTH_SECRET` — required by Auth.js; must be a strong random string in production.
-- `NEXTAUTH_URL` — set to the canonical deployment URL; required for OAuth redirects.
-- `NEXT_PUBLIC_ECHO_APP_ID` — only if needed for client-side Echo provider initialization.
-- Validate all required env vars at startup; fail fast with clear error messages.
-
-## Session & Protected Pages
-
-- Use `auth()` in Server Components/layouts to get the session and redirect unauthenticated users via `redirect('/login')`.
-- Do not trust client-supplied user identity; always derive user info from the server-side session.
-- Use middleware (`src/middleware.ts`) to protect entire route groups rather than repeating auth checks in each page.
-
-## App Router Conventions
-
-- Follow Next.js App Router structure: `page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`, `route.ts`.
-- Use `@/` path alias for all internal imports.
-- Default to Server Components; add `"use client"` only for interactive UI components.
-
-## Security
-
-- Never return raw provider tokens or internal error details to the client.
-- Rotate `NEXTAUTH_SECRET` on credential compromise; update all deployed environments.
-- Route all LLM calls through server Route Handlers authenticated via session or `isSignedIn`.
+- `ECHO_APP_ID` — Echo application identifier (also used as Auth.js client ID)
+- `AUTH_SECRET` — NextAuth secret for session encryption
+- `NEXTAUTH_URL` — Deployment URL for Auth.js callbacks

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,46 @@
+---
+description: Echo Next.js + Auth.js template rules covering Echo server wiring, Auth.js session handling, protected routes, client providers, and env safety
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js + Auth.js Template Rules
+
+## Echo Server Wiring
+
+- Keep Echo server setup centralized in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `openai`, `anthropic` from there.
+- The echo route (`src/app/api/echo/[...echo]/route.ts`) must stay as a thin passthrough: `export const { GET, POST } = handlers`.
+- Import from `@merit-systems/echo-next-sdk` in server code; use `@merit-systems/echo-next-sdk/client` in Client Components only.
+
+## Auth.js Integration
+
+- Define your Auth.js config in `src/auth.ts` (or `src/auth/index.ts`); export `auth`, `signIn`, `signOut`, and `handlers` from there.
+- Protect server routes and Server Components using the `auth()` helper — check `session.user` before proceeding.
+- Use `isSignedIn` from Echo (`src/echo/index.ts`) to additionally gate Echo-specific API usage; combine with Auth.js session checks when both are required.
+- Keep Auth.js providers, callbacks, and adapter config within the auth config file; do not scatter them across API routes.
+- For the Auth.js route, use `src/app/api/auth/[...nextauth]/route.ts` as a passthrough: `export const { GET, POST } = handlers`.
+
+## Environment Variables
+
+- `ECHO_APP_ID` — server-side Echo app identifier (never expose to client).
+- `NEXTAUTH_SECRET` — required by Auth.js; must be a strong random string in production.
+- `NEXTAUTH_URL` — set to the canonical deployment URL; required for OAuth redirects.
+- `NEXT_PUBLIC_ECHO_APP_ID` — only if needed for client-side Echo provider initialization.
+- Validate all required env vars at startup; fail fast with clear error messages.
+
+## Session & Protected Pages
+
+- Use `auth()` in Server Components/layouts to get the session and redirect unauthenticated users via `redirect('/login')`.
+- Do not trust client-supplied user identity; always derive user info from the server-side session.
+- Use middleware (`src/middleware.ts`) to protect entire route groups rather than repeating auth checks in each page.
+
+## App Router Conventions
+
+- Follow Next.js App Router structure: `page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`, `route.ts`.
+- Use `@/` path alias for all internal imports.
+- Default to Server Components; add `"use client"` only for interactive UI components.
+
+## Security
+
+- Never return raw provider tokens or internal error details to the client.
+- Rotate `NEXTAUTH_SECRET` on credential compromise; update all deployed environments.
+- Route all LLM calls through server Route Handlers authenticated via session or `isSignedIn`.

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,51 +1,24 @@
 ---
-description: Echo CLI template rules covering command architecture, auth flows, wallet handling, config management, output conventions, and error handling
-globs: **/*.{ts,js,mjs,cjs}
+description: Guidelines for building Echo-powered CLI applications, including SDK setup, authentication flows, wallet integration, and AI chat sessions
+globs: **/*.ts,**/*.js
 ---
 
-# Echo CLI Template Rules
+# Echo CLI Guidelines
 
-## Command Architecture
+## SDK Setup
+- Use `@merit-systems/echo-typescript-sdk` for server/CLI contexts
+- Use `@merit-systems/ai-x402` for x402 payment protocol integration
+- Use `@ai-sdk/openai` and `ai` for CLI chat
 
-- Define all CLI commands in `src/index.ts` using Commander; keep command `.action()` handlers thin — delegate to modules in `src/core/`, `src/auth/`, or `src/utils/`.
-- Organize business logic by domain: `src/core/` for chat/session logic, `src/auth/` for login/logout flows, `src/utils/` for shared helpers, `src/config/` for persistence.
-- Use `src/constants.ts` for all magic strings, ASCII art, and option arrays; never hardcode repeated values inline.
-- Register sub-commands as separate `program.command(...)` calls; do not nest all logic in a single giant command.
+## Authentication
+- Echo OAuth — Browser-based OAuth with PKCE
+- Crypto Wallet — WalletConnect or local wallet with private key
+- Use `conf` package for persistent configuration storage
 
-## Authentication Flows
+## CLI Framework
+- Use `commander` for command definitions
+- Use `@clack/prompts` for interactive selection
+- Use `chalk` for colored output, `ora` for spinners, `cli-table3` for tables
 
-- Gate commands that require authentication with the `isAuthenticated()` utility from `src/utils`; show a clear login prompt if the user is unauthenticated.
-- Use `loginWithEcho` and `loginWithWallet` from `src/auth` for the two supported auth modes; do not implement auth logic outside these modules.
-- Use `@clack/prompts` (`select`, `text`, `confirm`, `isCancel`) for all interactive prompts; always check `isCancel(result)` and exit cleanly with `process.exit(0)`.
-- Persist session/token data using the existing secure keychain/storage paths in `src/config`; never store sensitive values in plain files or env vars.
-
-## Wallet Handling
-
-- Use `initLocalWallet` and `exportPrivateKey` from `src/auth` for wallet creation/export; never generate or log key material outside these functions.
-- Show explicit user confirmation prompts before any wallet-destructive operations (export private key, fund wallet).
-- Display wallet addresses and balances using the print utilities in `src/print`; never construct raw `console.log` output for structured data.
-
-## Config & Environment
-
-- Read `ECHO_APP_ID` via the centralized constant in `src/constants.ts`; do not use `process.env.ECHO_APP_ID` directly in command handlers.
-- Store user preferences and session state in the config module (`src/config`); do not use ad-hoc files or global variables.
-- Validate required config at startup; surface clear error messages if `ECHO_APP_ID` or other required values are missing.
-
-## Output & UX Conventions
-
-- Use `info`, `warning`, `header`, and error utilities from `src/print` for all user-facing output; keep console output consistent in style.
-- Display the `ECHODEX_ASCII_ART` banner via `header()` at program startup and on appropriate subcommands.
-- Use `@clack/prompts` spinners for async operations that may take >1 second (network, wallet ops).
-- Handle `process.exit` semantics carefully: exit code `0` for user cancellation/clean exit, non-zero for errors.
-
-## Error Handling
-
-- Wrap async command handlers in try/catch; surface actionable error messages via `warning()` or `info()` — never raw stack traces in production mode.
-- For network failures (Echo API, wallet RPC), retry with backoff where appropriate; otherwise present a clear retry suggestion to the user.
-- Never crash silently; always give the user a next step (re-authenticate, check network, contact support).
-
-## TypeScript
-
-- Use strict TypeScript; add `@types/node` to `devDependencies` when using Node.js built-ins.
-- Type all function signatures explicitly; avoid inferred `any` from async operations.
-- Use `as const` for option arrays passed to `@clack/prompts` to get proper literal types.
+## Environment Variables
+- `ECHO_APP_ID` — Echo application identifier

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,51 @@
+---
+description: Echo CLI template rules covering command architecture, auth flows, wallet handling, config management, output conventions, and error handling
+globs: **/*.{ts,js,mjs,cjs}
+---
+
+# Echo CLI Template Rules
+
+## Command Architecture
+
+- Define all CLI commands in `src/index.ts` using Commander; keep command `.action()` handlers thin — delegate to modules in `src/core/`, `src/auth/`, or `src/utils/`.
+- Organize business logic by domain: `src/core/` for chat/session logic, `src/auth/` for login/logout flows, `src/utils/` for shared helpers, `src/config/` for persistence.
+- Use `src/constants.ts` for all magic strings, ASCII art, and option arrays; never hardcode repeated values inline.
+- Register sub-commands as separate `program.command(...)` calls; do not nest all logic in a single giant command.
+
+## Authentication Flows
+
+- Gate commands that require authentication with the `isAuthenticated()` utility from `src/utils`; show a clear login prompt if the user is unauthenticated.
+- Use `loginWithEcho` and `loginWithWallet` from `src/auth` for the two supported auth modes; do not implement auth logic outside these modules.
+- Use `@clack/prompts` (`select`, `text`, `confirm`, `isCancel`) for all interactive prompts; always check `isCancel(result)` and exit cleanly with `process.exit(0)`.
+- Persist session/token data using the existing secure keychain/storage paths in `src/config`; never store sensitive values in plain files or env vars.
+
+## Wallet Handling
+
+- Use `initLocalWallet` and `exportPrivateKey` from `src/auth` for wallet creation/export; never generate or log key material outside these functions.
+- Show explicit user confirmation prompts before any wallet-destructive operations (export private key, fund wallet).
+- Display wallet addresses and balances using the print utilities in `src/print`; never construct raw `console.log` output for structured data.
+
+## Config & Environment
+
+- Read `ECHO_APP_ID` via the centralized constant in `src/constants.ts`; do not use `process.env.ECHO_APP_ID` directly in command handlers.
+- Store user preferences and session state in the config module (`src/config`); do not use ad-hoc files or global variables.
+- Validate required config at startup; surface clear error messages if `ECHO_APP_ID` or other required values are missing.
+
+## Output & UX Conventions
+
+- Use `info`, `warning`, `header`, and error utilities from `src/print` for all user-facing output; keep console output consistent in style.
+- Display the `ECHODEX_ASCII_ART` banner via `header()` at program startup and on appropriate subcommands.
+- Use `@clack/prompts` spinners for async operations that may take >1 second (network, wallet ops).
+- Handle `process.exit` semantics carefully: exit code `0` for user cancellation/clean exit, non-zero for errors.
+
+## Error Handling
+
+- Wrap async command handlers in try/catch; surface actionable error messages via `warning()` or `info()` — never raw stack traces in production mode.
+- For network failures (Echo API, wallet RPC), retry with backoff where appropriate; otherwise present a clear retry suggestion to the user.
+- Never crash silently; always give the user a next step (re-authenticate, check network, contact support).
+
+## TypeScript
+
+- Use strict TypeScript; add `@types/node` to `devDependencies` when using Node.js built-ins.
+- Type all function signatures explicitly; avoid inferred `any` from async operations.
+- Use `as const` for option arrays passed to `@clack/prompts` to get proper literal types.

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,49 +1,24 @@
 ---
-description: Echo Next.js Chat template rules covering Echo server wiring, streaming chat, AI SDK patterns, client providers, message state, and env safety
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered Next.js chat applications with AI SDK streaming, shadcn/ui components, and real-time message handling
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ---
 
-# Echo Next.js Chat Template Rules
+# Echo Next.js Chat Guidelines
 
-## Echo Server Wiring
+## SDK Setup
+- Server-side: Initialize in `src/echo/index.ts` with `@merit-systems/echo-next-sdk`
+- Client-side: Wrap app with `EchoProvider` from `@merit-systems/echo-next-sdk/client`
+- Use `EchoTokens` component for authentication and token management
 
-- Keep Echo initialization in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `openai`, `anthropic` from there.
-- The echo route (`src/app/api/echo/[...echo]/route.ts`) must be a thin passthrough: `export const { GET, POST } = handlers`.
-- Import `@merit-systems/echo-next-sdk` in server code; use `@merit-systems/echo-next-sdk/client` in Client Components only.
+## Chat Integration
+- Use `useChat` hook from `@ai-sdk/react`
+- Use `streamText` from `ai` with Echo-proxied models in API routes
+- Always verify authentication with `isSignedIn()` before AI calls
 
-## Streaming Chat Architecture
-
-- Use the AI SDK (`streamText`, `convertToModelMessages`) for streaming responses; return `result.toUIMessageStream()` from server actions or route handlers.
-- Keep streaming logic within existing component boundaries (e.g., `ChatWrapper`); do not lift streaming state into layouts or global providers.
-- Handle stream errors at the component level with appropriate loading and error states; do not let unhandled promise rejections crash the UI.
-- Use `EchoChatProvider` from `@merit-systems/echo-react-sdk` to manage chat session state; do not build custom message state if the provider covers your use case.
-
-## Client Providers
-
-- Wrap the app root with `EchoProvider` (and `EchoChatProvider` where needed); pass `appId: import.meta.env.VITE_ECHO_APP_ID` (Vite) or `process.env.NEXT_PUBLIC_ECHO_APP_ID` (Next.js).
-- Use `useEcho()` and `useEchoModelProviders()` hooks to access the authenticated Echo client and model instances in Client Components.
-- Do not create additional provider wrappers unless you need to override default behavior; compose with existing providers instead.
-
-## Message State & UX
-
-- Maintain chat message history within the chat component or `EchoChatProvider`; do not persist messages to global state unless the template's existing pattern does so.
-- Show typing/loading indicators during streaming; disable the send button while a message is in-flight to prevent duplicate submissions.
-- Support graceful cancellation of in-flight streams via AbortController when the user navigates away or triggers a new request.
+## UI Components
+- Use shadcn/ui components
+- Use Tailwind CSS v4 for styling
 
 ## Environment Variables
-
-- `ECHO_APP_ID` — server-side only, for `src/echo/index.ts`.
-- `NEXT_PUBLIC_ECHO_APP_ID` — client-side provider config only.
-- Never embed provider API keys (OpenAI, Anthropic) in client code; route all model calls through the Echo server handler.
-
-## App Router Conventions
-
-- Use `@/` path alias for internal imports; never use deep relative paths.
-- Keep Server Components as the default; add `"use client"` only for interactive chat UI and hook consumers.
-- Use `loading.tsx` and `error.tsx` at appropriate route segments.
-
-## Security
-
-- All LLM inference calls must be proxied through the Echo server Route Handler; never call OpenAI/Anthropic APIs directly from the client.
-- Use `isSignedIn` to gate the chat route if authentication is required.
-- Sanitize user input before displaying it; avoid `dangerouslySetInnerHTML` with user-provided content.
+- `ECHO_APP_ID` — Server-side Echo identifier
+- `NEXT_PUBLIC_ECHO_APP_ID` — Client-side Echo identifier

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,49 @@
+---
+description: Echo Next.js Chat template rules covering Echo server wiring, streaming chat, AI SDK patterns, client providers, message state, and env safety
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js Chat Template Rules
+
+## Echo Server Wiring
+
+- Keep Echo initialization in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `openai`, `anthropic` from there.
+- The echo route (`src/app/api/echo/[...echo]/route.ts`) must be a thin passthrough: `export const { GET, POST } = handlers`.
+- Import `@merit-systems/echo-next-sdk` in server code; use `@merit-systems/echo-next-sdk/client` in Client Components only.
+
+## Streaming Chat Architecture
+
+- Use the AI SDK (`streamText`, `convertToModelMessages`) for streaming responses; return `result.toUIMessageStream()` from server actions or route handlers.
+- Keep streaming logic within existing component boundaries (e.g., `ChatWrapper`); do not lift streaming state into layouts or global providers.
+- Handle stream errors at the component level with appropriate loading and error states; do not let unhandled promise rejections crash the UI.
+- Use `EchoChatProvider` from `@merit-systems/echo-react-sdk` to manage chat session state; do not build custom message state if the provider covers your use case.
+
+## Client Providers
+
+- Wrap the app root with `EchoProvider` (and `EchoChatProvider` where needed); pass `appId: import.meta.env.VITE_ECHO_APP_ID` (Vite) or `process.env.NEXT_PUBLIC_ECHO_APP_ID` (Next.js).
+- Use `useEcho()` and `useEchoModelProviders()` hooks to access the authenticated Echo client and model instances in Client Components.
+- Do not create additional provider wrappers unless you need to override default behavior; compose with existing providers instead.
+
+## Message State & UX
+
+- Maintain chat message history within the chat component or `EchoChatProvider`; do not persist messages to global state unless the template's existing pattern does so.
+- Show typing/loading indicators during streaming; disable the send button while a message is in-flight to prevent duplicate submissions.
+- Support graceful cancellation of in-flight streams via AbortController when the user navigates away or triggers a new request.
+
+## Environment Variables
+
+- `ECHO_APP_ID` — server-side only, for `src/echo/index.ts`.
+- `NEXT_PUBLIC_ECHO_APP_ID` — client-side provider config only.
+- Never embed provider API keys (OpenAI, Anthropic) in client code; route all model calls through the Echo server handler.
+
+## App Router Conventions
+
+- Use `@/` path alias for internal imports; never use deep relative paths.
+- Keep Server Components as the default; add `"use client"` only for interactive chat UI and hook consumers.
+- Use `loading.tsx` and `error.tsx` at appropriate route segments.
+
+## Security
+
+- All LLM inference calls must be proxied through the Echo server Route Handler; never call OpenAI/Anthropic APIs directly from the client.
+- Use `isSignedIn` to gate the chat route if authentication is required.
+- Sanitize user input before displaying it; avoid `dangerouslySetInnerHTML` with user-provided content.

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,50 +1,24 @@
 ---
-description: Echo Next.js Image Generation template rules covering Echo server wiring, image generation flows, provider config, file handling, and env safety
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered Next.js image generation applications with AI SDK, image models, and gallery components
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ---
 
-# Echo Next.js Image Generation Template Rules
+# Echo Next.js Image Generation Guidelines
 
-## Echo Server Wiring
+## SDK Setup
+- Server-side: Initialize in `src/echo/index.ts` with `@merit-systems/echo-next-sdk`
+- Client-side: Wrap app with `EchoProvider` from `@merit-systems/echo-next-sdk/client`
+- Use `EchoTokens` component for authentication and token management
 
-- Keep Echo initialization in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `openai`, `anthropic`, `google` and other provider helpers from there.
-- The echo route (`src/app/api/echo/[...echo]/route.ts`) must be a thin passthrough: `export const { GET, POST } = handlers`.
-- Use `ECHO_APP_ID` for server-side initialization; never expose it to the client bundle.
-- Import from `@merit-systems/echo-next-sdk` in server code; use `@merit-systems/echo-next-sdk/client` in Client Components only.
+## Image Generation
+- Use `experimental_generateImage` from `ai` for image generation
+- Display generated images with proper loading states
+- Use `next/image` for optimized image rendering when possible
 
-## Image Generation Flows
-
-- Invoke image generation through the Echo-proxied provider client (e.g., `openai`, `google` from `src/echo/index.ts`); never call provider image APIs directly from client code.
-- Handle image generation as an async server-side operation; return URLs or base64 data from Route Handlers, not the raw provider response object.
-- Validate prompt inputs server-side before forwarding to the provider; reject empty or excessively long prompts with appropriate HTTP error responses.
-- Include model-specific parameters (size, quality, style, n) as named options; document supported values in a comment near the call site.
-
-## File & Asset Handling
-
-- Store generated images using Next.js public folder conventions or an external storage service; do not store binary data in the database.
-- Use Next.js `<Image>` component for displaying generated images to benefit from automatic optimization and lazy loading.
-- Set appropriate `alt` text on all generated images for accessibility.
+## UI Components
+- Use shadcn/ui components
+- Build a gallery component for displaying generated images
 
 ## Environment Variables
-
-- `ECHO_APP_ID` — server-side Echo app identifier.
-- `NEXT_PUBLIC_ECHO_APP_ID` — client-side provider config only.
-- Add any additional provider-specific keys (e.g., `GOOGLE_API_KEY`) to `.env.local` and document them in `.env.example`; never commit real values.
-
-## Client vs. Server
-
-- Trigger image generation from Server Actions or Route Handlers; client code should only submit the prompt and display results.
-- In client components, use `useEcho()` or `useEchoModelProviders()` hooks from `@merit-systems/echo-next-sdk/client` or `@merit-systems/echo-react-sdk`.
-- Show progress/loading state during generation (image generation typically takes 5–30 seconds).
-
-## App Router Conventions
-
-- Use `@/` path alias for all internal imports.
-- Use Server Components for data fetching and generation triggers; use Client Components only for interactive UI (prompt form, image gallery).
-- Handle generation errors in `error.tsx` or inline with try/catch in Server Actions.
-
-## Security
-
-- Implement rate limiting on image generation routes to prevent abuse.
-- Do not pass raw user input as system prompts; sanitize or constrain prompt inputs before forwarding.
-- Log generation requests for audit purposes but never log the full provider API response including billing metadata.
+- `ECHO_APP_ID` — Server-side Echo identifier
+- `NEXT_PUBLIC_ECHO_APP_ID` — Client-side Echo identifier

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,50 @@
+---
+description: Echo Next.js Image Generation template rules covering Echo server wiring, image generation flows, provider config, file handling, and env safety
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js Image Generation Template Rules
+
+## Echo Server Wiring
+
+- Keep Echo initialization in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `openai`, `anthropic`, `google` and other provider helpers from there.
+- The echo route (`src/app/api/echo/[...echo]/route.ts`) must be a thin passthrough: `export const { GET, POST } = handlers`.
+- Use `ECHO_APP_ID` for server-side initialization; never expose it to the client bundle.
+- Import from `@merit-systems/echo-next-sdk` in server code; use `@merit-systems/echo-next-sdk/client` in Client Components only.
+
+## Image Generation Flows
+
+- Invoke image generation through the Echo-proxied provider client (e.g., `openai`, `google` from `src/echo/index.ts`); never call provider image APIs directly from client code.
+- Handle image generation as an async server-side operation; return URLs or base64 data from Route Handlers, not the raw provider response object.
+- Validate prompt inputs server-side before forwarding to the provider; reject empty or excessively long prompts with appropriate HTTP error responses.
+- Include model-specific parameters (size, quality, style, n) as named options; document supported values in a comment near the call site.
+
+## File & Asset Handling
+
+- Store generated images using Next.js public folder conventions or an external storage service; do not store binary data in the database.
+- Use Next.js `<Image>` component for displaying generated images to benefit from automatic optimization and lazy loading.
+- Set appropriate `alt` text on all generated images for accessibility.
+
+## Environment Variables
+
+- `ECHO_APP_ID` — server-side Echo app identifier.
+- `NEXT_PUBLIC_ECHO_APP_ID` — client-side provider config only.
+- Add any additional provider-specific keys (e.g., `GOOGLE_API_KEY`) to `.env.local` and document them in `.env.example`; never commit real values.
+
+## Client vs. Server
+
+- Trigger image generation from Server Actions or Route Handlers; client code should only submit the prompt and display results.
+- In client components, use `useEcho()` or `useEchoModelProviders()` hooks from `@merit-systems/echo-next-sdk/client` or `@merit-systems/echo-react-sdk`.
+- Show progress/loading state during generation (image generation typically takes 5–30 seconds).
+
+## App Router Conventions
+
+- Use `@/` path alias for all internal imports.
+- Use Server Components for data fetching and generation triggers; use Client Components only for interactive UI (prompt form, image gallery).
+- Handle generation errors in `error.tsx` or inline with try/catch in Server Actions.
+
+## Security
+
+- Implement rate limiting on image generation routes to prevent abuse.
+- Do not pass raw user input as system prompts; sanitize or constrain prompt inputs before forwarding.
+- Log generation requests for audit purposes but never log the full provider API response including billing metadata.

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,50 +1,24 @@
 ---
-description: Echo Next.js Video Generation template rules covering Echo server wiring, video generation flows, multi-provider config (openai/anthropic/google), async job handling, and env safety
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered Next.js video generation applications with AI video models and video player components
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ---
 
-# Echo Next.js Video Generation Template Rules
+# Echo Next.js Video Generation Guidelines
 
-## Echo Server Wiring
+## SDK Setup
+- Server-side: Initialize in `src/echo/index.ts` with `@merit-systems/echo-next-sdk`
+- Client-side: Wrap app with `EchoProvider` from `@merit-systems/echo-next-sdk/client`
+- Use `EchoTokens` component for authentication and token management
 
-- Keep Echo initialization in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `openai`, `anthropic`, `google`, `getUser`, `getEchoToken` from there.
-- The echo route (`src/app/api/echo/[...echo]/route.ts`) must remain a thin passthrough: `export const { GET, POST } = handlers`.
-- Use `ECHO_APP_ID` for server-side initialization; never expose this to the client.
-- Import from `@merit-systems/echo-next-sdk` in server code; use `@merit-systems/echo-next-sdk/client` in Client Components only.
+## Video Generation
+- Use Echo-proxied models for video generation
+- Build a custom video player or use HTML5 `<video>` element
+- Support playback controls: play, pause, seek, volume
 
-## Video Generation Flows
-
-- Invoke video generation through Echo-proxied provider clients (`openai`, `google`, `anthropic` from `src/echo/index.ts`); never call Sora, Veo, or other video provider APIs directly from client code.
-- Video generation is long-running; implement an async job pattern — submit the generation request, return a job ID, and poll for completion or use webhooks.
-- Return job status and video URLs from Route Handlers, not raw provider response payloads.
-- Validate prompt inputs server-side: enforce length limits, reject banned content categories, and normalize whitespace before forwarding.
-
-## Multi-Provider Handling
-
-- This template may use OpenAI (Sora), Google (Veo), or other providers; keep provider selection configurable via request parameters or environment variables.
-- Abstract provider-specific request shapes behind a shared server function; do not scatter provider-specific code across multiple route files.
-- Document which providers are enabled by which env vars; fail fast with clear errors when a requested provider is not configured.
-
-## Async Job Management
-
-- Track generation jobs server-side (in-memory for development, persistent storage for production); associate jobs with the requesting user via `getUser()` from Echo.
-- Implement job status polling endpoint at a well-known path; return `{ status: 'pending' | 'complete' | 'failed', url?: string, error?: string }`.
-- Clean up completed or failed job records after a reasonable TTL to prevent memory/storage leaks.
-
-## File & Asset Handling
-
-- Store generated videos in external object storage (S3, GCS, R2); do not stream large video blobs through Next.js responses.
-- Use signed URLs with appropriate expiry for video delivery; do not expose storage bucket paths directly.
-- Use Next.js `<video>` element with proper `controls`, `preload`, and `poster` attributes for video playback.
+## UI Components
+- Use shadcn/ui components
+- Build a video gallery with thumbnails
 
 ## Environment Variables
-
-- `ECHO_APP_ID` — server-side Echo app identifier.
-- `NEXT_PUBLIC_ECHO_APP_ID` — client-side provider config only.
-- Add provider-specific keys to `.env.example`; document the required format and where to obtain them.
-
-## Security & Rate Limiting
-
-- Implement per-user rate limiting on video generation routes; video generation is expensive.
-- Use `isSignedIn` from Echo or `getUser()` to authenticate all generation requests; reject unauthenticated requests with 401.
-- Do not log full provider responses; they may contain billing metadata or PII.
+- `ECHO_APP_ID` — Server-side Echo identifier
+- `NEXT_PUBLIC_ECHO_APP_ID` — Client-side Echo identifier

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,50 @@
+---
+description: Echo Next.js Video Generation template rules covering Echo server wiring, video generation flows, multi-provider config (openai/anthropic/google), async job handling, and env safety
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js Video Generation Template Rules
+
+## Echo Server Wiring
+
+- Keep Echo initialization in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `openai`, `anthropic`, `google`, `getUser`, `getEchoToken` from there.
+- The echo route (`src/app/api/echo/[...echo]/route.ts`) must remain a thin passthrough: `export const { GET, POST } = handlers`.
+- Use `ECHO_APP_ID` for server-side initialization; never expose this to the client.
+- Import from `@merit-systems/echo-next-sdk` in server code; use `@merit-systems/echo-next-sdk/client` in Client Components only.
+
+## Video Generation Flows
+
+- Invoke video generation through Echo-proxied provider clients (`openai`, `google`, `anthropic` from `src/echo/index.ts`); never call Sora, Veo, or other video provider APIs directly from client code.
+- Video generation is long-running; implement an async job pattern — submit the generation request, return a job ID, and poll for completion or use webhooks.
+- Return job status and video URLs from Route Handlers, not raw provider response payloads.
+- Validate prompt inputs server-side: enforce length limits, reject banned content categories, and normalize whitespace before forwarding.
+
+## Multi-Provider Handling
+
+- This template may use OpenAI (Sora), Google (Veo), or other providers; keep provider selection configurable via request parameters or environment variables.
+- Abstract provider-specific request shapes behind a shared server function; do not scatter provider-specific code across multiple route files.
+- Document which providers are enabled by which env vars; fail fast with clear errors when a requested provider is not configured.
+
+## Async Job Management
+
+- Track generation jobs server-side (in-memory for development, persistent storage for production); associate jobs with the requesting user via `getUser()` from Echo.
+- Implement job status polling endpoint at a well-known path; return `{ status: 'pending' | 'complete' | 'failed', url?: string, error?: string }`.
+- Clean up completed or failed job records after a reasonable TTL to prevent memory/storage leaks.
+
+## File & Asset Handling
+
+- Store generated videos in external object storage (S3, GCS, R2); do not stream large video blobs through Next.js responses.
+- Use signed URLs with appropriate expiry for video delivery; do not expose storage bucket paths directly.
+- Use Next.js `<video>` element with proper `controls`, `preload`, and `poster` attributes for video playback.
+
+## Environment Variables
+
+- `ECHO_APP_ID` — server-side Echo app identifier.
+- `NEXT_PUBLIC_ECHO_APP_ID` — client-side provider config only.
+- Add provider-specific keys to `.env.example`; document the required format and where to obtain them.
+
+## Security & Rate Limiting
+
+- Implement per-user rate limiting on video generation routes; video generation is expensive.
+- Use `isSignedIn` from Echo or `getUser()` to authenticate all generation requests; reject unauthenticated requests with 401.
+- Do not log full provider responses; they may contain billing metadata or PII.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,50 @@
+---
+description: Echo Next.js template rules covering server wiring, client providers, App Router conventions, env handling, TypeScript patterns, and error handling
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js Template Rules
+
+## Server Wiring
+
+- Keep all Echo server setup centralized in `src/echo/index.ts`; never scatter Echo initialization across multiple files.
+- The echo route must remain a thin passthrough — `export const { GET, POST } = handlers` in `src/app/api/echo/[...echo]/route.ts`. Do not add business logic here.
+- Use `ECHO_APP_ID` (no `NEXT_PUBLIC_` prefix) for server-side Echo initialization; this value must never be exposed to the client bundle.
+- Export named helpers (`handlers`, `isSignedIn`, `openai`, `anthropic`) from `src/echo/index.ts` and import them wherever needed.
+
+## Client vs. Server Imports
+
+- In Server Components and Route Handlers: import from `@merit-systems/echo-next-sdk`.
+- In Client Components (`"use client"`): import from `@merit-systems/echo-next-sdk/client`.
+- Never import server-only Echo modules in client components; this will cause build errors or secret leakage.
+
+## Environment Variables
+
+- Use `ECHO_APP_ID` for server-side config.
+- Use `NEXT_PUBLIC_ECHO_APP_ID` only for values that must reach the browser (e.g., client-side provider config).
+- Never commit `.env.local`; verify `.gitignore` includes it.
+- Validate required env vars at startup using a guard like `if (!process.env.ECHO_APP_ID) throw new Error(...)`.
+
+## App Router Conventions
+
+- Follow Next.js App Router file conventions: `page.tsx`, `layout.tsx`, `route.ts`, `loading.tsx`, `error.tsx`.
+- Use path alias `@/` (maps to `src/`) for all internal imports; avoid relative `../../` traversal.
+- Keep Server Components as the default; only add `"use client"` when component needs interactivity or browser APIs.
+
+## TypeScript
+
+- Enable strict TypeScript; never use `any` — use `unknown` and narrow with type guards instead.
+- Use the non-null assertion operator (`!`) on env vars only if you guard them above (e.g., `process.env.ECHO_APP_ID!` after a startup check).
+- Prefer `type` over `interface` for plain data shapes; use `interface` for extendable contracts.
+
+## Error Handling
+
+- Use Next.js `error.tsx` boundaries to catch and display errors at the route segment level.
+- Return appropriate HTTP status codes from Route Handlers (`NextResponse.json({...}, { status: 400 })`).
+- Never expose raw error messages from Echo or upstream providers to the client.
+
+## Security
+
+- Route all LLM/model API calls through server Route Handlers; never call provider APIs directly from client code.
+- Use `isSignedIn` middleware from `src/echo/index.ts` to protect routes that require authentication.
+- Do not log sensitive values (tokens, keys, session data) in production code.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,50 +1,28 @@
 ---
-description: Echo Next.js template rules covering server wiring, client providers, App Router conventions, env handling, TypeScript patterns, and error handling
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered Next.js applications, including SDK setup, provider configuration, API routes, and AI integration
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ---
 
-# Echo Next.js Template Rules
+# Echo Next.js Guidelines
 
-## Server Wiring
+## SDK Setup
+- Server-side: Initialize in `src/echo/index.ts` with `@merit-systems/echo-next-sdk`
+- Client-side: Wrap app with `EchoProvider` from `@merit-systems/echo-next-sdk/client`
+- API route: Create catch-all at `src/app/api/echo/[...echo]/route.ts`
 
-- Keep all Echo server setup centralized in `src/echo/index.ts`; never scatter Echo initialization across multiple files.
-- The echo route must remain a thin passthrough — `export const { GET, POST } = handlers` in `src/app/api/echo/[...echo]/route.ts`. Do not add business logic here.
-- Use `ECHO_APP_ID` (no `NEXT_PUBLIC_` prefix) for server-side Echo initialization; this value must never be exposed to the client bundle.
-- Export named helpers (`handlers`, `isSignedIn`, `openai`, `anthropic`) from `src/echo/index.ts` and import them wherever needed.
+## AI Integration
+- Always import AI models from `@/echo`, not directly from `@ai-sdk/openai`
+- Use Vercel AI SDK v5 patterns for streaming
+- Use `isSignedIn()` from `@/echo` to verify authentication
 
-## Client vs. Server Imports
-
-- In Server Components and Route Handlers: import from `@merit-systems/echo-next-sdk`.
-- In Client Components (`"use client"`): import from `@merit-systems/echo-next-sdk/client`.
-- Never import server-only Echo modules in client components; this will cause build errors or secret leakage.
+## Components
+- Use `EchoTokens` component for auth/token purchase UI (client component)
 
 ## Environment Variables
+- `ECHO_APP_ID` — Server-side Echo app identifier
+- `NEXT_PUBLIC_ECHO_APP_ID` — Client-side Echo app identifier
 
-- Use `ECHO_APP_ID` for server-side config.
-- Use `NEXT_PUBLIC_ECHO_APP_ID` only for values that must reach the browser (e.g., client-side provider config).
-- Never commit `.env.local`; verify `.gitignore` includes it.
-- Validate required env vars at startup using a guard like `if (!process.env.ECHO_APP_ID) throw new Error(...)`.
-
-## App Router Conventions
-
-- Follow Next.js App Router file conventions: `page.tsx`, `layout.tsx`, `route.ts`, `loading.tsx`, `error.tsx`.
-- Use path alias `@/` (maps to `src/`) for all internal imports; avoid relative `../../` traversal.
-- Keep Server Components as the default; only add `"use client"` when component needs interactivity or browser APIs.
-
-## TypeScript
-
-- Enable strict TypeScript; never use `any` — use `unknown` and narrow with type guards instead.
-- Use the non-null assertion operator (`!`) on env vars only if you guard them above (e.g., `process.env.ECHO_APP_ID!` after a startup check).
-- Prefer `type` over `interface` for plain data shapes; use `interface` for extendable contracts.
-
-## Error Handling
-
-- Use Next.js `error.tsx` boundaries to catch and display errors at the route segment level.
-- Return appropriate HTTP status codes from Route Handlers (`NextResponse.json({...}, { status: 400 })`).
-- Never expose raw error messages from Echo or upstream providers to the client.
-
-## Security
-
-- Route all LLM/model API calls through server Route Handlers; never call provider APIs directly from client code.
-- Use `isSignedIn` middleware from `src/echo/index.ts` to protect routes that require authentication.
-- Do not log sensitive values (tokens, keys, session data) in production code.
+## Common Patterns
+- Use Next.js 15 App Router (not Pages Router)
+- Use Tailwind CSS v4 for styling
+- Use `@/` path alias for imports from `src/`

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,52 +1,26 @@
 ---
-description: Echo Next.js API-key template rules covering Echo + Prisma wiring, createEchoOpenAI usage, user API key storage, streaming chat, database patterns, and env safety
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered Next.js applications with server-side API key management, PostgreSQL database, and Prisma ORM
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.prisma
 ---
 
-# Echo Next.js API Key Template Rules
+# Echo Next.js API Key Template Guidelines
 
-## Echo Server Wiring
+## SDK Setup
+- Server-side: Initialize Echo in `src/echo/index.ts` with `@merit-systems/echo-next-sdk`
+- Client-side: Wrap app with `EchoProvider` from `@merit-systems/echo-next-sdk/client`
+- Also uses `@merit-systems/echo-typescript-sdk` for server-side API calls
 
-- Keep Echo initialization in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `getUser` from there.
-- The echo route (`src/app/api/echo/[...echo]/route.ts`) must be a thin passthrough: `export const { GET, POST } = handlers`.
-- Use `ECHO_APP_ID` for server-side Echo config; never expose to the client.
+## Database (Prisma + PostgreSQL)
+- Define models in `prisma/schema.prisma`
+- Use `@prisma/client` for database queries
+- Use global singleton pattern to prevent too many connections in development
 
-## createEchoOpenAI Pattern
-
-- Use `createEchoOpenAI` from `@merit-systems/echo-typescript-sdk` in Route Handlers to create a per-request OpenAI-compatible client that uses the user's stored API key.
-- Pass a callback that retrieves the API key from the database (via Prisma); never hardcode or inline API keys.
-- Pass an insufficient-funds callback as the third argument; return an appropriate `Response` with HTTP 402 and a clear error message.
-- Always validate that `getUser()` returns a non-null user before querying their API key; throw with a descriptive error if not.
-
-## API Key Storage & Management
-
-- Store user API keys in the database (Prisma `db.user`) using the existing `apiKey` field; never store keys in cookies or local storage.
-- Use the `useValidApiKey` hook from `src/app/_components/accept-api-key/hooks` to check API key status in client components; do not re-implement this logic inline.
-- Show appropriate onboarding UI when `requiresSetup` is true; gate the main chat interface on `hasValidApiKey`.
-- Encrypt API keys at rest if the deployment handles sensitive provider keys; document the encryption approach in the README.
-
-## Streaming Chat Route
-
-- Keep the chat Route Handler (`src/app/api/chat/route.ts`) as the single entry point for LLM inference.
-- Validate `model` and `messages` parameters before forwarding to the provider; return HTTP 400 with a descriptive message for missing/invalid params.
-- Use `streamText` from the AI SDK with `convertToModelMessages` for message normalization; return `result.toUIMessageStreamResponse({ sendSources: true, sendReasoning: true })`.
-- Set `export const maxDuration = 30` (or higher) on streaming routes to prevent Vercel timeout errors.
-
-## Database Patterns (Prisma)
-
-- Use `src/lib/db.ts` as the single Prisma client instance; never instantiate `PrismaClient` elsewhere.
-- Use `db.user.findUnique` with `select` to fetch only the fields you need; avoid fetching entire user objects when only `apiKey` is required.
-- Handle Prisma errors explicitly; distinguish between "not found" (null return) and actual database errors.
+## API Key Management
+- Store API keys securely in the database (hashed)
+- Validate API keys on each request
+- Support key rotation and revocation
 
 ## Environment Variables
-
-- `ECHO_APP_ID` — server-side Echo app identifier.
-- `DATABASE_URL` — Prisma database connection string; never commit to source control.
-- `NEXT_PUBLIC_ECHO_APP_ID` — only if needed for client-side Echo provider.
-- Document all required env vars in `.env.example`.
-
-## Security
-
-- Use `getUser()` from Echo to authenticate every API route; return 401 for unauthenticated requests.
-- Never log API keys, even partially; treat them as secrets throughout the codebase.
-- Validate and sanitize the `model` parameter against an allowlist to prevent model enumeration or abuse.
+- `ECHO_APP_ID` — Server-side Echo app identifier
+- `NEXT_PUBLIC_ECHO_APP_ID` — Client-side Echo app identifier
+- `DATABASE_URL` — PostgreSQL connection string

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,52 @@
+---
+description: Echo Next.js API-key template rules covering Echo + Prisma wiring, createEchoOpenAI usage, user API key storage, streaming chat, database patterns, and env safety
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo Next.js API Key Template Rules
+
+## Echo Server Wiring
+
+- Keep Echo initialization in `src/echo/index.ts`; export `handlers`, `isSignedIn`, `getUser` from there.
+- The echo route (`src/app/api/echo/[...echo]/route.ts`) must be a thin passthrough: `export const { GET, POST } = handlers`.
+- Use `ECHO_APP_ID` for server-side Echo config; never expose to the client.
+
+## createEchoOpenAI Pattern
+
+- Use `createEchoOpenAI` from `@merit-systems/echo-typescript-sdk` in Route Handlers to create a per-request OpenAI-compatible client that uses the user's stored API key.
+- Pass a callback that retrieves the API key from the database (via Prisma); never hardcode or inline API keys.
+- Pass an insufficient-funds callback as the third argument; return an appropriate `Response` with HTTP 402 and a clear error message.
+- Always validate that `getUser()` returns a non-null user before querying their API key; throw with a descriptive error if not.
+
+## API Key Storage & Management
+
+- Store user API keys in the database (Prisma `db.user`) using the existing `apiKey` field; never store keys in cookies or local storage.
+- Use the `useValidApiKey` hook from `src/app/_components/accept-api-key/hooks` to check API key status in client components; do not re-implement this logic inline.
+- Show appropriate onboarding UI when `requiresSetup` is true; gate the main chat interface on `hasValidApiKey`.
+- Encrypt API keys at rest if the deployment handles sensitive provider keys; document the encryption approach in the README.
+
+## Streaming Chat Route
+
+- Keep the chat Route Handler (`src/app/api/chat/route.ts`) as the single entry point for LLM inference.
+- Validate `model` and `messages` parameters before forwarding to the provider; return HTTP 400 with a descriptive message for missing/invalid params.
+- Use `streamText` from the AI SDK with `convertToModelMessages` for message normalization; return `result.toUIMessageStreamResponse({ sendSources: true, sendReasoning: true })`.
+- Set `export const maxDuration = 30` (or higher) on streaming routes to prevent Vercel timeout errors.
+
+## Database Patterns (Prisma)
+
+- Use `src/lib/db.ts` as the single Prisma client instance; never instantiate `PrismaClient` elsewhere.
+- Use `db.user.findUnique` with `select` to fetch only the fields you need; avoid fetching entire user objects when only `apiKey` is required.
+- Handle Prisma errors explicitly; distinguish between "not found" (null return) and actual database errors.
+
+## Environment Variables
+
+- `ECHO_APP_ID` — server-side Echo app identifier.
+- `DATABASE_URL` — Prisma database connection string; never commit to source control.
+- `NEXT_PUBLIC_ECHO_APP_ID` — only if needed for client-side Echo provider.
+- Document all required env vars in `.env.example`.
+
+## Security
+
+- Use `getUser()` from Echo to authenticate every API route; return 401 for unauthenticated requests.
+- Never log API keys, even partially; treat them as secrets throughout the codebase.
+- Validate and sanitize the `model` parameter against an allowlist to prevent model enumeration or abuse.

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,51 +1,25 @@
 ---
-description: Echo React Chat (Vite) template rules covering EchoProvider + EchoChatProvider setup, chat hooks, streaming message state, AI SDK usage, and client-safe patterns
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered React chat applications with Vite, AI SDK streaming, and shadcn/ui components
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ---
 
-# Echo React Chat (Vite) Template Rules
+# Echo React Chat Guidelines
 
-## Provider Setup
+## SDK Setup
+- Wrap app with `EchoProvider` from `@merit-systems/echo-react-sdk`
+- Use `import.meta.env.VITE_ECHO_APP_ID` for the Echo app identifier
+- Use `EchoTokens` component for authentication and token management
 
-- Wrap the app root with `EchoProvider` first, then `EchoChatProvider` as a child; pass `config={{ appId: import.meta.env.VITE_ECHO_APP_ID }}` to `EchoProvider`.
-- Never nest providers in the wrong order; `EchoChatProvider` depends on the Echo context provided by `EchoProvider`.
-- Do not create redundant providers; one `EchoProvider` at root is sufficient for the entire app.
+## Chat Integration
+- Use `useChat` hook from `@ai-sdk/react`
 
-## Hook & SDK Usage
+## UI Components
+- Use shadcn/ui components
+- Tailwind CSS for styling
 
-- Use `useEcho()` from `@merit-systems/echo-react-sdk` to access authentication state and user info.
-- Use `useEchoModelProviders()` to get the `openai` (and other) provider clients; pass them to AI SDK functions like `streamText`.
-- Use `useChat` from `@merit-systems/echo-react-sdk` for chat session management where applicable; do not rebuild chat state from scratch.
-- Keep streaming and message-state logic within existing component boundaries (e.g., `ChatWrapper`); do not lift streaming state into global context.
+## Environment Variables
+- `VITE_ECHO_APP_ID` — Client-side Echo identifier (Vite prefix required)
 
-## Streaming Chat Pattern
-
-- Pass `ChatSendParams` (containing `messages`) to the chat send handler; use `convertToModelMessages` from the AI SDK to normalize message format.
-- Use `streamText` from the AI SDK with the Echo-provided model client; return `result.toUIMessageStream()` as the response.
-- Handle in-flight requests with a loading state; disable the input/send button while a message is being streamed.
-- Support request cancellation via `AbortController` when the user navigates away or sends a new message.
-
-## Message UX
-
-- Display messages in chronological order; new messages append to the bottom.
-- Show a typing indicator while the stream is active.
-- Handle empty states (no messages yet) with a friendly prompt.
-- Render assistant messages with markdown formatting if the template supports it.
-
-## Environment Variables (Vite)
-
-- Use `import.meta.env.VITE_ECHO_APP_ID` for the Echo app ID; prefix all public env vars with `VITE_`.
-- Never embed provider API keys in the client bundle; all model calls are proxied through Echo's backend.
-- Document required env vars in `.env.example` or README.
-
-## Component Structure
-
-- Keep `src/App.tsx` as the root provider + layout shell.
-- Split chat UI into focused components: `Chat` (container), message list, message item, input area.
-- Follow existing Vite + React patterns for module paths, component layout, styling, and TypeScript strictness.
-
-## Security
-
-- All LLM inference is proxied through Echo's backend; the client only sends prompts and receives streamed text.
-- Only `VITE_ECHO_APP_ID` belongs in client env vars; keep all other credentials server-side.
-- Sanitize rendered assistant output if displaying as HTML; prefer a markdown renderer with safe defaults.
+## Build & Development
+- Dev: `npm run dev` (Vite)
+- This is a client-side only app — no SSR

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,51 @@
+---
+description: Echo React Chat (Vite) template rules covering EchoProvider + EchoChatProvider setup, chat hooks, streaming message state, AI SDK usage, and client-safe patterns
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo React Chat (Vite) Template Rules
+
+## Provider Setup
+
+- Wrap the app root with `EchoProvider` first, then `EchoChatProvider` as a child; pass `config={{ appId: import.meta.env.VITE_ECHO_APP_ID }}` to `EchoProvider`.
+- Never nest providers in the wrong order; `EchoChatProvider` depends on the Echo context provided by `EchoProvider`.
+- Do not create redundant providers; one `EchoProvider` at root is sufficient for the entire app.
+
+## Hook & SDK Usage
+
+- Use `useEcho()` from `@merit-systems/echo-react-sdk` to access authentication state and user info.
+- Use `useEchoModelProviders()` to get the `openai` (and other) provider clients; pass them to AI SDK functions like `streamText`.
+- Use `useChat` from `@merit-systems/echo-react-sdk` for chat session management where applicable; do not rebuild chat state from scratch.
+- Keep streaming and message-state logic within existing component boundaries (e.g., `ChatWrapper`); do not lift streaming state into global context.
+
+## Streaming Chat Pattern
+
+- Pass `ChatSendParams` (containing `messages`) to the chat send handler; use `convertToModelMessages` from the AI SDK to normalize message format.
+- Use `streamText` from the AI SDK with the Echo-provided model client; return `result.toUIMessageStream()` as the response.
+- Handle in-flight requests with a loading state; disable the input/send button while a message is being streamed.
+- Support request cancellation via `AbortController` when the user navigates away or sends a new message.
+
+## Message UX
+
+- Display messages in chronological order; new messages append to the bottom.
+- Show a typing indicator while the stream is active.
+- Handle empty states (no messages yet) with a friendly prompt.
+- Render assistant messages with markdown formatting if the template supports it.
+
+## Environment Variables (Vite)
+
+- Use `import.meta.env.VITE_ECHO_APP_ID` for the Echo app ID; prefix all public env vars with `VITE_`.
+- Never embed provider API keys in the client bundle; all model calls are proxied through Echo's backend.
+- Document required env vars in `.env.example` or README.
+
+## Component Structure
+
+- Keep `src/App.tsx` as the root provider + layout shell.
+- Split chat UI into focused components: `Chat` (container), message list, message item, input area.
+- Follow existing Vite + React patterns for module paths, component layout, styling, and TypeScript strictness.
+
+## Security
+
+- All LLM inference is proxied through Echo's backend; the client only sends prompts and receives streamed text.
+- Only `VITE_ECHO_APP_ID` belongs in client env vars; keep all other credentials server-side.
+- Sanitize rendered assistant output if displaying as HTML; prefer a markdown renderer with safe defaults.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,49 @@
+---
+description: Echo React Image Generation (Vite) template rules covering EchoProvider setup, image generation hooks, prompt handling, display conventions, and client-safe patterns
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo React Image Generation (Vite) Template Rules
+
+## Provider Setup
+
+- Initialize `EchoProvider` at the app root (`src/main.tsx` or `src/App.tsx`) with `config={{ appId: import.meta.env.VITE_ECHO_APP_ID! }}`.
+- Only one `EchoProvider` instance at the tree root; do not re-initialize it in child components.
+
+## Hook & SDK Usage
+
+- Use `useEcho()` from `@merit-systems/echo-react-sdk` to access the Echo client and auth state.
+- Use `useEchoModelProviders()` to get image-capable provider clients; do not construct provider clients manually.
+- Keep image generation invocations (API calls) in component handlers or custom hooks; do not trigger generation as a side effect of rendering.
+
+## Image Generation UX
+
+- Show a loading spinner or progress indicator during image generation (typically 5–30 seconds); disable the generate button while in-flight.
+- Display generated images using `<img>` with descriptive `alt` text derived from the prompt.
+- Support generating multiple images per request if the provider/template supports it; display them in a responsive grid.
+- Allow users to download generated images; use an anchor tag with `download` attribute pointing to the image URL or blob.
+- Handle generation errors gracefully — show a user-friendly error message with a retry option.
+
+## Prompt Handling
+
+- Validate prompts client-side before submission: require non-empty input, enforce reasonable length limits (e.g., ≤1000 characters).
+- Preserve the last submitted prompt in the input field so users can refine and regenerate.
+- Consider adding a prompt history feature using local state or `localStorage` for convenience.
+
+## Environment Variables (Vite)
+
+- Use `import.meta.env.VITE_ECHO_APP_ID` for the Echo app ID; this is the only Echo-related env var for the client.
+- Never embed provider API keys in the client bundle; image generation is proxied through Echo's backend.
+- Document required env vars in `.env.example`.
+
+## Component Structure
+
+- Keep `src/main.tsx` minimal: root rendering, global styles, and `EchoProvider`.
+- Structure image generation UI into focused components: prompt input, generate button, image gallery, image card.
+- Follow existing Vite + React patterns for module paths, component layout, styling, and TypeScript strictness.
+
+## Security & Rate Limiting
+
+- All image generation calls are proxied through Echo's backend; the client only submits prompts and receives image URLs.
+- Only `VITE_ECHO_APP_ID` belongs in client env vars; all provider keys remain server-side.
+- Consider implementing client-side debounce on the generate button to prevent accidental double-submissions.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,49 +1,26 @@
 ---
-description: Echo React Image Generation (Vite) template rules covering EchoProvider setup, image generation hooks, prompt handling, display conventions, and client-safe patterns
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered React image generation applications with Vite and AI image models
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ---
 
-# Echo React Image Generation (Vite) Template Rules
+# Echo React Image Generation Guidelines
 
-## Provider Setup
+## SDK Setup
+- Wrap app with `EchoProvider` from `@merit-systems/echo-react-sdk`
+- Use `import.meta.env.VITE_ECHO_APP_ID` for the Echo app identifier
+- Use `EchoTokens` component for authentication and token management
 
-- Initialize `EchoProvider` at the app root (`src/main.tsx` or `src/App.tsx`) with `config={{ appId: import.meta.env.VITE_ECHO_APP_ID! }}`.
-- Only one `EchoProvider` instance at the tree root; do not re-initialize it in child components.
+## Image Generation
+- Use `@ai-sdk/react` hooks for prompt submission
+- Display generated images with loading states
 
-## Hook & SDK Usage
+## UI Components
+- Use shadcn/ui components
+- Tailwind CSS for styling
 
-- Use `useEcho()` from `@merit-systems/echo-react-sdk` to access the Echo client and auth state.
-- Use `useEchoModelProviders()` to get image-capable provider clients; do not construct provider clients manually.
-- Keep image generation invocations (API calls) in component handlers or custom hooks; do not trigger generation as a side effect of rendering.
+## Environment Variables
+- `VITE_ECHO_APP_ID` — Client-side Echo identifier (Vite prefix required)
 
-## Image Generation UX
-
-- Show a loading spinner or progress indicator during image generation (typically 5–30 seconds); disable the generate button while in-flight.
-- Display generated images using `<img>` with descriptive `alt` text derived from the prompt.
-- Support generating multiple images per request if the provider/template supports it; display them in a responsive grid.
-- Allow users to download generated images; use an anchor tag with `download` attribute pointing to the image URL or blob.
-- Handle generation errors gracefully — show a user-friendly error message with a retry option.
-
-## Prompt Handling
-
-- Validate prompts client-side before submission: require non-empty input, enforce reasonable length limits (e.g., ≤1000 characters).
-- Preserve the last submitted prompt in the input field so users can refine and regenerate.
-- Consider adding a prompt history feature using local state or `localStorage` for convenience.
-
-## Environment Variables (Vite)
-
-- Use `import.meta.env.VITE_ECHO_APP_ID` for the Echo app ID; this is the only Echo-related env var for the client.
-- Never embed provider API keys in the client bundle; image generation is proxied through Echo's backend.
-- Document required env vars in `.env.example`.
-
-## Component Structure
-
-- Keep `src/main.tsx` minimal: root rendering, global styles, and `EchoProvider`.
-- Structure image generation UI into focused components: prompt input, generate button, image gallery, image card.
-- Follow existing Vite + React patterns for module paths, component layout, styling, and TypeScript strictness.
-
-## Security & Rate Limiting
-
-- All image generation calls are proxied through Echo's backend; the client only submits prompts and receives image URLs.
-- Only `VITE_ECHO_APP_ID` belongs in client env vars; all provider keys remain server-side.
-- Consider implementing client-side debounce on the generate button to prevent accidental double-submissions.
+## Build & Development
+- Dev: `npm run dev` (Vite)
+- This is a client-side only app — no SSR

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,49 @@
+---
+description: Echo React (Vite) template rules covering EchoProvider setup, hook usage, client-safe env vars, component structure, and TypeScript patterns
+globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+---
+
+# Echo React (Vite) Template Rules
+
+## EchoProvider Setup
+
+- Initialize `EchoProvider` at the app root in `src/main.tsx` (or `src/App.tsx`); pass `config={{ appId: import.meta.env.VITE_ECHO_APP_ID! }}`.
+- Never initialize multiple `EchoProvider` instances; there should be exactly one at the React tree root.
+- Do not render the app if `import.meta.env.VITE_ECHO_APP_ID` is missing; add a guard that shows a setup error in development.
+
+## Hook & SDK Usage
+
+- Use `useEcho()` from `@merit-systems/echo-react-sdk` to access the authenticated Echo client, user info, and sign-in state.
+- Use `EchoTokens` from `@merit-systems/echo-react-sdk` to display user token/balance information; do not build a custom balance display unless the SDK component is insufficient.
+- Use `useEchoModelProviders()` to get provider-specific clients (e.g., `openai`); do not construct model clients manually.
+- Do not create custom wrapper hooks around Echo SDK hooks unless you need to add application-specific logic on top.
+
+## Environment Variables (Vite)
+
+- Use `import.meta.env.VITE_ECHO_APP_ID` for the Echo app ID; this is the only Echo-related env var that belongs in client code.
+- Never add provider API keys (OpenAI, Anthropic) to Vite env vars; all model calls must be proxied through a server or Echo's backend.
+- Prefix all custom public env vars with `VITE_`; non-prefixed env vars are not accessible in the browser bundle.
+- Document required env vars in `.env.example`.
+
+## Component Structure
+
+- Keep `src/App.tsx` focused on layout and provider composition; extract feature components into `src/components/`.
+- This is a pure client-side SPA; there is no server-side rendering or Route Handlers. All Echo API calls go through the SDK's client-side hooks.
+- For any operations requiring secrets or server-side logic, create a separate backend (e.g., an Express server or Next.js API route) and call it from the client.
+
+## TypeScript
+
+- Enable strict TypeScript in `tsconfig.app.json`; avoid `any` types.
+- Type component props explicitly; use `React.FC<Props>` or inline function types.
+- Use `as const` for configuration objects passed to providers.
+
+## Styling & Conventions
+
+- Follow existing Vite + React patterns in this template for module paths, component layout, and CSS approach.
+- Use the existing CSS modules or Tailwind setup (whichever this template uses); do not mix styling approaches.
+- Keep `src/main.tsx` minimal — only root rendering, global styles, and provider setup.
+
+## Security
+
+- All credentials and provider secrets must remain server-side; only the public Echo app ID belongs in Vite env vars.
+- If you need to add server-side features, keep them in a separate server package; do not embed backend logic in the Vite client bundle.

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,49 +1,22 @@
 ---
-description: Echo React (Vite) template rules covering EchoProvider setup, hook usage, client-safe env vars, component structure, and TypeScript patterns
-globs: **/*.{ts,tsx,js,jsx,mjs,cjs}
+description: Guidelines for building Echo-powered React applications with Vite, including SDK setup, provider configuration, and AI integration
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ---
 
-# Echo React (Vite) Template Rules
+# Echo React (Vite) Guidelines
 
-## EchoProvider Setup
+## SDK Setup
+- Wrap app with `EchoProvider` from `@merit-systems/echo-react-sdk`
+- Use `import.meta.env.VITE_ECHO_APP_ID` for environment variables (Vite convention)
+- Use `EchoTokens` component for auth and token purchases
 
-- Initialize `EchoProvider` at the app root in `src/main.tsx` (or `src/App.tsx`); pass `config={{ appId: import.meta.env.VITE_ECHO_APP_ID! }}`.
-- Never initialize multiple `EchoProvider` instances; there should be exactly one at the React tree root.
-- Do not render the app if `import.meta.env.VITE_ECHO_APP_ID` is missing; add a guard that shows a setup error in development.
+## AI Integration
+- Use `@ai-sdk/react` hooks for chat and completion UIs
+- React 19 is used — leverage new features like `use()` hook
 
-## Hook & SDK Usage
+## Environment Variables
+- `VITE_ECHO_APP_ID` — Echo app identifier (client-side, exposed to browser)
 
-- Use `useEcho()` from `@merit-systems/echo-react-sdk` to access the authenticated Echo client, user info, and sign-in state.
-- Use `EchoTokens` from `@merit-systems/echo-react-sdk` to display user token/balance information; do not build a custom balance display unless the SDK component is insufficient.
-- Use `useEchoModelProviders()` to get provider-specific clients (e.g., `openai`); do not construct model clients manually.
-- Do not create custom wrapper hooks around Echo SDK hooks unless you need to add application-specific logic on top.
-
-## Environment Variables (Vite)
-
-- Use `import.meta.env.VITE_ECHO_APP_ID` for the Echo app ID; this is the only Echo-related env var that belongs in client code.
-- Never add provider API keys (OpenAI, Anthropic) to Vite env vars; all model calls must be proxied through a server or Echo's backend.
-- Prefix all custom public env vars with `VITE_`; non-prefixed env vars are not accessible in the browser bundle.
-- Document required env vars in `.env.example`.
-
-## Component Structure
-
-- Keep `src/App.tsx` focused on layout and provider composition; extract feature components into `src/components/`.
-- This is a pure client-side SPA; there is no server-side rendering or Route Handlers. All Echo API calls go through the SDK's client-side hooks.
-- For any operations requiring secrets or server-side logic, create a separate backend (e.g., an Express server or Next.js API route) and call it from the client.
-
-## TypeScript
-
-- Enable strict TypeScript in `tsconfig.app.json`; avoid `any` types.
-- Type component props explicitly; use `React.FC<Props>` or inline function types.
-- Use `as const` for configuration objects passed to providers.
-
-## Styling & Conventions
-
-- Follow existing Vite + React patterns in this template for module paths, component layout, and CSS approach.
-- Use the existing CSS modules or Tailwind setup (whichever this template uses); do not mix styling approaches.
-- Keep `src/main.tsx` minimal — only root rendering, global styles, and provider setup.
-
-## Security
-
-- All credentials and provider secrets must remain server-side; only the public Echo app ID belongs in Vite env vars.
-- If you need to add server-side features, keep them in a separate server package; do not embed backend logic in the Vite client bundle.
+## Common Patterns
+- Build with Vite: `npm run dev`
+- No server-side rendering — pure client-side app


### PR DESCRIPTION
## Summary

Adds `.cursor/rules/echo_rules.mdc` to all 11 echo-start templates so that new projects created with `echo-start` include Cursor AI coding rules tailored to each template's architecture.

Closes #636

## What's included

A rules file was added to every template with rules specific to that template's stack and patterns:

| Template | Stack | Key rules |
|---|---|---|
| `next` | Next.js App Router | Echo server wiring, client vs. server imports, env vars, security |
| `authjs` | Next.js + Auth.js | Echo + Auth.js integration, session-based auth gating |
| `next-chat` | Next.js + AI SDK streaming | Streaming chat, EchoChatProvider, message state |
| `next-image` | Next.js + image generation | Image gen flows, multi-provider, file handling |
| `next-video-template` | Next.js + video generation | Async job pattern, multi-provider (Sora/Veo), rate limiting |
| `assistant-ui` | Next.js + assistant-ui | Root `echo.ts` wiring, `NEXT_PUBLIC_ECHO_APP_ID` usage |
| `nextjs-api-key-template` | Next.js + Prisma + API keys | `createEchoOpenAI`, per-user API key storage, streaming chat |
| `react` | React + Vite | `EchoProvider` setup, `useEcho`, `EchoTokens`, Vite env vars |
| `react-chat` | React + Vite + AI SDK | `EchoChatProvider`, streaming hooks, message UX |
| `react-image` | React + Vite + image gen | Image generation UX, prompt handling, display conventions |
| `echo-cli` | Node.js CLI (Commander) | Command architecture, auth flows, wallet handling, Clack prompts |

## Improvements over existing approaches

- **Template-specific rules**: Each template gets rules derived from its actual source code (imports, file structure, SDK usage), not generic copy-paste.
- **Organized sections**: Rules are grouped by concern (server wiring, env vars, security, TypeScript, etc.) for easier scanning.
- **More comprehensive**: Rules cover error handling, security, TypeScript patterns, and UX conventions in depth.
- **Covers all 11 templates**: Full coverage across every echo-start template.
- **Based on real code**: Rules reference actual exported names, file paths, and patterns from each template's source.