### PR TITLE
Fix #595: Support Veo 3.1 in the veo provider

### DIFF
--- a/packages/app/server/src/providers/VertexAIProvider.ts
+++ b/packages/app/server/src/providers/VertexAIProvider.ts
@@ -19,6 +19,8 @@ import { env } from '../env';
 // Constants
 export const PROXY_PASSTHROUGH_ONLY_MODEL = 'PROXY_PLACEHOLDER_VERTEX_AI';
 const VEO3_MODELS = [
+  'veo-3.1-fast-generate-preview',
+  'veo-3.1-generate-preview',
   'veo-3.0-fast-generate-preview',
   'veo-3.0-generate-preview',
 ];

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -1,6 +1,8 @@
 import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 /**
@@ -12,15 +14,27 @@ export type VertexAIVideoModel =
  */
 export const VertexAIVideoModels: SupportedVideoModel[] = [
   {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
+  {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,
-    cost_per_second_without_audio: 0.1, // Fixed: was 0.1, now 0.10 for clarity
+    cost_per_second_without_audio: 0.1,
     provider: 'VertexAI',
   },
   {
     model_id: 'veo-3.0-generate-preview',
-    cost_per_second_with_audio: 0.4, // Fixed: was 0.4, now 0.40 for clarity
-    cost_per_second_without_audio: 0.2, // Fixed: was 0.2, now 0.20 for clarity
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
     provider: 'VertexAI',
   },
 ];

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,8 +35,8 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
-    'veo-3.0-fast-generate-preview',
-    'veo-3.0-generate-preview',
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
   ];
   if (!model || !validModels.includes(model as VideoModelOption)) {
     return {

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -4,6 +4,7 @@
 
 import { getEchoToken } from '@/echo';
 import { ERROR_MESSAGES } from '@/lib/constants';
+import type { VideoModelOption } from '@/lib/types';
 import {
   GenerateVideosOperation,
   GenerateVideosParameters,
@@ -14,7 +15,7 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model: VideoModelOption,
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,8 +42,8 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
-  { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
-  { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1' },
 ];
 
 /**
@@ -57,7 +57,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-preview'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,8 +14,8 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
-  | 'veo-3.0-fast-generate-preview'
-  | 'veo-3.0-generate-preview';
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview';
 
 /**
  * Model configuration with display names


### PR DESCRIPTION
## Summary

This PR resolves #595.

### Changes

Added Veo 3.1 preview model support to Vertex AI router model registries and updated the next-video template to use Veo 3.1 models as the available/default options.

### Files Modified

- `packages/sdk/ts/src/supported-models/video/vertex-ai.ts`
- `packages/app/server/src/providers/VertexAIProvider.ts`
- `templates/next-video-template/src/lib/types.ts`
- `templates/next-video-template/src/components/video-generator.tsx`
- `templates/next-video-template/src/app/api/generate-video/validation.ts`
- `templates/next-video-template/src/app/api/generate-video/vertex.ts`
- `DONE.json`

Happy to address any feedback or make adjustments.

/claim #595