### PR TITLE
feat: add Vercel AI Gateway as a provider

### DIFF
--- a/packages/app/server/src/env.ts
+++ b/packages/app/server/src/env.ts
@@ -45,6 +45,7 @@ export const env = createEnv({
     GROQ_API_KEY: z.string().optional(),
     XAI_API_KEY: z.string().optional(),
     OPENROUTER_API_KEY: z.string().optional(),
+    VERCEL_AI_GATEWAY_API_KEY: z.string().optional(),
     TAVILY_API_KEY: z.string().optional(),
     E2B_API_KEY: z.string().optional(),
     GOOGLE_SERVICE_ACCOUNT_KEY_ENCODED: z.string().optional(),

--- a/packages/app/server/src/providers/ProviderFactory.ts
+++ b/packages/app/server/src/providers/ProviderFactory.ts
@@ -21,6 +21,7 @@ import { OpenAIImageProvider } from './OpenAIImageProvider';
 import { OpenAIResponsesProvider } from './OpenAIResponsesProvider';
 import { OpenRouterProvider } from './OpenRouterProvider';
 import { ProviderType } from './ProviderType';
+import { VercelAIGatewayProvider } from './VercelAIGatewayProvider';
 import { XAIProvider } from './XAIProvider';
 import {
   VertexAIProvider,
@@ -57,6 +58,10 @@ const createChatModelToProviderMapping = (): Record<string, ProviderType> => {
         case 'XAI':
         case 'Xai':
           mapping[modelConfig.model_id] = ProviderType.XAI;
+          break;
+        case 'Vercel':
+        case 'VercelAIGateway':
+          mapping[modelConfig.model_id] = ProviderType.VERCEL_AI_GATEWAY;
           break;
         // Add other providers as needed
         default:
@@ -192,6 +197,8 @@ export const getProvider = (
       return new GroqProvider(stream, model);
     case ProviderType.XAI:
       return new XAIProvider(stream, model);
+    case ProviderType.VERCEL_AI_GATEWAY:
+      return new VercelAIGatewayProvider(stream, model);
     default:
       throw new Error(`Unknown provider type: ${type}`);
   }

--- a/packages/app/server/src/providers/ProviderType.ts
+++ b/packages/app/server/src/providers/ProviderType.ts
@@ -12,4 +12,5 @@ export enum ProviderType {
   OPENAI_VIDEOS = 'OPENAI_VIDEOS',
   GROQ = 'GROQ',
   XAI = 'XAI',
+  VERCEL_AI_GATEWAY = 'VERCEL_AI_GATEWAY',
 }

--- a/packages/app/server/src/providers/VercelAIGatewayProvider.ts
+++ b/packages/app/server/src/providers/VercelAIGatewayProvider.ts
@@ -1,0 +1,82 @@
+import { LlmTransactionMetadata, Transaction } from '../types';
+import { getCostPerToken } from '../services/AccountingService';
+import { BaseProvider } from './BaseProvider';
+import { ProviderType } from './ProviderType';
+import { CompletionStateBody, parseSSEGPTFormat } from './GPTProvider';
+import logger from '../logger';
+import { env } from '../env';
+
+export class VercelAIGatewayProvider extends BaseProvider {
+  private readonly VERCEL_AI_GATEWAY_BASE_URL =
+    'https://ai-gateway.vercel.sh/v1';
+
+  getType(): ProviderType {
+    return ProviderType.VERCEL_AI_GATEWAY;
+  }
+
+  getBaseUrl(): string {
+    return this.VERCEL_AI_GATEWAY_BASE_URL;
+  }
+
+  getApiKey(): string | undefined {
+    return env.VERCEL_AI_GATEWAY_API_KEY;
+  }
+
+  override supportsStream(): boolean {
+    return true;
+  }
+
+  async handleBody(data: string): Promise<Transaction> {
+    try {
+      let prompt_tokens = 0;
+      let completion_tokens = 0;
+      let total_tokens = 0;
+      let providerId = 'null';
+
+      if (this.getIsStream()) {
+        const chunks = parseSSEGPTFormat(data);
+
+        for (const chunk of chunks) {
+          if (chunk.usage !== null) {
+            prompt_tokens += chunk.usage.prompt_tokens;
+            completion_tokens += chunk.usage.completion_tokens;
+            total_tokens += chunk.usage.total_tokens;
+          }
+          providerId = chunk.id || 'null';
+        }
+      } else {
+        const parsed = JSON.parse(data) as CompletionStateBody;
+        prompt_tokens += parsed.usage.prompt_tokens;
+        completion_tokens += parsed.usage.completion_tokens;
+        total_tokens += parsed.usage.total_tokens;
+        providerId = parsed.id || 'null';
+      }
+
+      const cost = getCostPerToken(
+        this.getModel(),
+        prompt_tokens,
+        completion_tokens
+      );
+
+      const metadata: LlmTransactionMetadata = {
+        providerId: providerId,
+        provider: this.getType(),
+        model: this.getModel(),
+        inputTokens: prompt_tokens,
+        outputTokens: completion_tokens,
+        totalTokens: total_tokens,
+      };
+
+      const transaction: Transaction = {
+        rawTransactionCost: cost,
+        metadata: metadata,
+        status: 'success',
+      };
+
+      return transaction;
+    } catch (error) {
+      logger.error(`Error processing data: ${error}`);
+      throw error;
+    }
+  }
+}

--- a/packages/app/server/src/services/AccountingService.ts
+++ b/packages/app/server/src/services/AccountingService.ts
@@ -10,6 +10,7 @@ import {
   SupportedImageModel,
   SupportedVideoModel,
   XAIModels,
+  VercelModels,
 } from '@merit-systems/echo-typescript-sdk';
 
 import { Decimal } from '@prisma/client/runtime/library';
@@ -30,6 +31,7 @@ export const ALL_SUPPORTED_MODELS: SupportedModel[] = [
   ...OpenRouterModels,
   ...GroqModels,
   ...XAIModels,
+  ...VercelModels,
 ];
 
 // Handle image models separately since they have different pricing structure

--- a/packages/sdk/ts/package.json
+++ b/packages/sdk/ts/package.json
@@ -29,7 +29,8 @@
     "update-models:gemini": "tsx scripts/update-gemini-models.ts",
     "update-models:openrouter": "tsx scripts/update-openrouter-models.ts",
     "update-models:groq": "tsx scripts/update-groq-models.ts",
-    "update-all-models": "pnpm run update-models:openai && pnpm run update-models:anthropic && pnpm run update-models:gemini && pnpm run update-models:openrouter && pnpm run update-models:groq",
+    "update-models:vercel": "tsx scripts/update-vercel-models.ts",
+    "update-all-models": "pnpm run update-models:openai && pnpm run update-models:anthropic && pnpm run update-models:gemini && pnpm run update-models:openrouter && pnpm run update-models:groq && pnpm run update-models:vercel",
     "prepublishOnly": "pnpm run build"
   },
   "keywords": [
@@ -58,6 +59,7 @@
   ],
   "dependencies": {
     "@ai-sdk/anthropic": "2.0.17",
+    "@ai-sdk/gateway": "^1.0.12",
     "@ai-sdk/google": "2.0.14",
     "@ai-sdk/groq": "2.0.17",
     "@ai-sdk/openai": "2.0.32",

--- a/packages/sdk/ts/scripts/update-vercel-models.ts
+++ b/packages/sdk/ts/scripts/update-vercel-models.ts
@@ -1,26 +1,52 @@
 #!/usr/bin/env node
 
 // -> Fetch all available models from the Vercel AI Gateway
-// Uses the @ai-sdk/gateway package to get model IDs and pricing
+// Uses the public models endpoint to get model IDs and pricing
 // Writes to src/supported-models/chat/vercel.ts
 
-import { gateway } from '@ai-sdk/gateway';
 import { generateModelFile, type SupportedModel } from './update-models';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
+
+interface VercelGatewayModel {
+  id: string;
+  type: string;
+  pricing?: {
+    input: string;
+    output: string;
+  } | null;
+}
+
+interface VercelGatewayResponse {
+  object: string;
+  data: VercelGatewayModel[];
+}
 
 async function updateVercelModels(): Promise<void> {
   try {
     console.log('🔄 Starting Vercel AI Gateway model update process...\n');
 
-    // Fetch available models directly from the gateway API
+    // Fetch available models from the public gateway endpoint
     console.log('📡 Fetching available models from Vercel AI Gateway...');
-    const response = await gateway.getAvailableModels();
+    const response = await fetch('https://ai-gateway.vercel.sh/v1/models');
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch models: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const data: VercelGatewayResponse = await response.json();
+    console.log(`🔍 Found ${data.data.length} total models from gateway`);
 
     // Filter for language models with pricing
-    const models: SupportedModel[] = response.models
-      .filter(model => model.modelType === 'language')
-      .filter(model => model.pricing?.input != null && model.pricing?.output != null)
+    const models: SupportedModel[] = data.data
+      .filter(
+        model =>
+          model.type === 'language' &&
+          model.pricing?.input != null &&
+          model.pricing?.output != null
+      )
       .map(model => ({
         model_id: model.id,
         input_cost_per_token: Number(model.pricing!.input),
@@ -28,16 +54,21 @@ async function updateVercelModels(): Promise<void> {
         provider: 'Vercel',
       }));
 
-    console.log(`\n📝 Found ${models.length} language models with pricing`);
+    console.log(`📝 Filtered to ${models.length} language models with pricing`);
 
     // Generate the file content
     const fileContent = generateModelFile(models, 'Vercel', 'Vercel');
 
     // Write the updated file
-    const outputPath = join(process.cwd(), 'src/supported-models/chat/vercel.ts');
+    const outputPath = join(
+      process.cwd(),
+      'src/supported-models/chat/vercel.ts'
+    );
     writeFileSync(outputPath, fileContent, 'utf8');
 
-    console.log(`\n✅ Successfully updated vercel.ts with ${models.length} models`);
+    console.log(
+      `\n✅ Successfully updated vercel.ts with ${models.length} models`
+    );
     console.log('📊 Models included:');
     models.forEach(model => {
       console.log(`  - ${model.model_id}`);

--- a/packages/sdk/ts/scripts/update-vercel-models.ts
+++ b/packages/sdk/ts/scripts/update-vercel-models.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+// -> Fetch all available models from the Vercel AI Gateway
+// Uses the @ai-sdk/gateway package to get model IDs and pricing
+// Writes to src/supported-models/chat/vercel.ts
+
+import { gateway } from '@ai-sdk/gateway';
+import { generateModelFile, type SupportedModel } from './update-models';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+async function updateVercelModels(): Promise<void> {
+  try {
+    console.log('🔄 Starting Vercel AI Gateway model update process...\n');
+
+    // Fetch available models directly from the gateway API
+    console.log('📡 Fetching available models from Vercel AI Gateway...');
+    const response = await gateway.getAvailableModels();
+
+    // Filter for language models with pricing
+    const models: SupportedModel[] = response.models
+      .filter(model => model.modelType === 'language')
+      .filter(model => model.pricing?.input != null && model.pricing?.output != null)
+      .map(model => ({
+        model_id: model.id,
+        input_cost_per_token: Number(model.pricing!.input),
+        output_cost_per_token: Number(model.pricing!.output),
+        provider: 'Vercel',
+      }));
+
+    console.log(`\n📝 Found ${models.length} language models with pricing`);
+
+    // Generate the file content
+    const fileContent = generateModelFile(models, 'Vercel', 'Vercel');
+
+    // Write the updated file
+    const outputPath = join(process.cwd(), 'src/supported-models/chat/vercel.ts');
+    writeFileSync(outputPath, fileContent, 'utf8');
+
+    console.log(`\n✅ Successfully updated vercel.ts with ${models.length} models`);
+    console.log('📊 Models included:');
+    models.forEach(model => {
+      console.log(`  - ${model.model_id}`);
+    });
+  } catch (error) {
+    console.error('❌ Error updating Vercel AI Gateway models:', error);
+    process.exit(1);
+  }
+}
+
+// Run the script
+updateVercelModels().catch(error => {
+  console.error('❌ Unexpected error:', error);
+  process.exit(1);
+});

--- a/packages/sdk/ts/src/index.ts
+++ b/packages/sdk/ts/src/index.ts
@@ -49,6 +49,8 @@ export { GroqModels } from './supported-models/chat/groq';
 export type { GroqModel } from './supported-models/chat/groq';
 export { XAIModels } from './supported-models/chat/xai';
 export type { XAIModel } from './supported-models/chat/xai';
+export { VercelModels } from './supported-models/chat/vercel';
+export type { VercelModel } from './supported-models/chat/vercel';
 export { OpenAIImageModels } from './supported-models/image/openai';
 export type { OpenAIImageModel } from './supported-models/image/openai';
 export { GeminiVideoModels } from './supported-models/video/gemini';

--- a/packages/sdk/ts/src/providers/index.ts
+++ b/packages/sdk/ts/src/providers/index.ts
@@ -4,6 +4,7 @@ export * from './groq';
 export * from './xai';
 export * from './openai';
 export * from './openrouter';
+export * from './vercel';
 
 export function echoFetch(
   originalFetch: typeof fetch,
@@ -63,3 +64,4 @@ export { type GroqProvider } from '@ai-sdk/groq';
 export { type OpenAIProvider } from '@ai-sdk/openai';
 export { type OpenRouterProvider } from '@openrouter/ai-sdk-provider';
 export { type XaiProvider } from '@ai-sdk/xai';
+export { type GatewayProvider } from '@ai-sdk/gateway';

--- a/packages/sdk/ts/src/providers/vercel.ts
+++ b/packages/sdk/ts/src/providers/vercel.ts
@@ -1,0 +1,23 @@
+import { createGateway as createGatewayBase } from '@ai-sdk/gateway';
+import { ROUTER_BASE_URL } from 'config';
+import { EchoConfig } from '../types';
+import { validateAppId } from '../utils/validation';
+import { echoFetch } from './index';
+
+export function createEchoVercelAIGateway(
+  { appId, baseRouterUrl = ROUTER_BASE_URL }: EchoConfig,
+  getTokenFn: (appId: string) => Promise<string | null>,
+  onInsufficientFunds?: () => void
+) {
+  validateAppId(appId, 'createEchoVercelAIGateway');
+
+  return createGatewayBase({
+    baseURL: baseRouterUrl,
+    apiKey: 'placeholder_replaced_by_echoFetch',
+    fetch: echoFetch(
+      fetch,
+      async () => await getTokenFn(appId),
+      onInsufficientFunds
+    ),
+  });
+}

--- a/packages/sdk/ts/src/supported-models/chat/vercel.ts
+++ b/packages/sdk/ts/src/supported-models/chat/vercel.ts
@@ -1,15 +1,26 @@
 import { SupportedModel } from '../types';
 
-// Vercel AI Gateway model IDs
-// Models accessed through the Vercel AI Gateway use the format: provider/model-id
-// Pricing sourced from: Vercel AI Gateway API (gateway.getAvailableModels())
-// Last updated: 2026-03-20
+// Union type of all valid Vercel model IDs
 export type VercelModel =
   | 'alibaba/qwen-3-14b'
   | 'alibaba/qwen-3-235b'
   | 'alibaba/qwen-3-30b'
   | 'alibaba/qwen-3-32b'
+  | 'alibaba/qwen3-235b-a22b-thinking'
   | 'alibaba/qwen3-coder'
+  | 'alibaba/qwen3-coder-30b-a3b'
+  | 'alibaba/qwen3-coder-next'
+  | 'alibaba/qwen3-coder-plus'
+  | 'alibaba/qwen3-max'
+  | 'alibaba/qwen3-max-preview'
+  | 'alibaba/qwen3-max-thinking'
+  | 'alibaba/qwen3-next-80b-a3b-instruct'
+  | 'alibaba/qwen3-next-80b-a3b-thinking'
+  | 'alibaba/qwen3-vl-instruct'
+  | 'alibaba/qwen3-vl-thinking'
+  | 'alibaba/qwen3.5-flash'
+  | 'alibaba/qwen3.5-plus'
+  | 'amazon/nova-2-lite'
   | 'amazon/nova-lite'
   | 'amazon/nova-micro'
   | 'amazon/nova-pro'
@@ -17,96 +28,293 @@ export type VercelModel =
   | 'anthropic/claude-3-opus'
   | 'anthropic/claude-3.5-haiku'
   | 'anthropic/claude-3.5-sonnet'
+  | 'anthropic/claude-3.5-sonnet-20240620'
   | 'anthropic/claude-3.7-sonnet'
+  | 'anthropic/claude-haiku-4.5'
   | 'anthropic/claude-opus-4'
+  | 'anthropic/claude-opus-4.1'
+  | 'anthropic/claude-opus-4.5'
+  | 'anthropic/claude-opus-4.6'
   | 'anthropic/claude-sonnet-4'
+  | 'anthropic/claude-sonnet-4.5'
+  | 'anthropic/claude-sonnet-4.6'
+  | 'arcee-ai/trinity-large-preview'
+  | 'arcee-ai/trinity-mini'
+  | 'bytedance/seed-1.6'
+  | 'bytedance/seed-1.8'
   | 'cohere/command-a'
-  | 'cohere/command-r'
-  | 'cohere/command-r-plus'
   | 'deepseek/deepseek-r1'
   | 'deepseek/deepseek-v3'
   | 'deepseek/deepseek-v3.1'
+  | 'deepseek/deepseek-v3.1-terminus'
+  | 'deepseek/deepseek-v3.2'
+  | 'deepseek/deepseek-v3.2-thinking'
   | 'google/gemini-2.0-flash'
   | 'google/gemini-2.0-flash-lite'
   | 'google/gemini-2.5-flash'
+  | 'google/gemini-2.5-flash-image'
+  | 'google/gemini-2.5-flash-lite'
   | 'google/gemini-2.5-pro'
+  | 'google/gemini-3-flash'
+  | 'google/gemini-3-pro-image'
+  | 'google/gemini-3-pro-preview'
+  | 'google/gemini-3.1-flash-image-preview'
+  | 'google/gemini-3.1-flash-lite-preview'
+  | 'google/gemini-3.1-pro-preview'
+  | 'inception/mercury-2'
+  | 'inception/mercury-coder-small'
+  | 'kwaipilot/kat-coder-pro-v1'
+  | 'meituan/longcat-flash-thinking'
   | 'meta/llama-3.1-70b'
   | 'meta/llama-3.1-8b'
+  | 'meta/llama-3.2-11b'
+  | 'meta/llama-3.2-1b'
+  | 'meta/llama-3.2-3b'
+  | 'meta/llama-3.2-90b'
   | 'meta/llama-3.3-70b'
   | 'meta/llama-4-maverick'
   | 'meta/llama-4-scout'
-  | 'mistral/mistral-large'
+  | 'minimax/minimax-m2'
+  | 'minimax/minimax-m2.1'
+  | 'minimax/minimax-m2.1-lightning'
+  | 'minimax/minimax-m2.5'
+  | 'minimax/minimax-m2.5-highspeed'
+  | 'minimax/minimax-m2.7'
+  | 'minimax/minimax-m2.7-highspeed'
+  | 'mistral/codestral'
+  | 'mistral/devstral-2'
+  | 'mistral/devstral-small'
+  | 'mistral/devstral-small-2'
+  | 'mistral/magistral-medium'
+  | 'mistral/magistral-small'
+  | 'mistral/ministral-14b'
+  | 'mistral/ministral-3b'
+  | 'mistral/ministral-8b'
+  | 'mistral/mistral-large-3'
+  | 'mistral/mistral-medium'
+  | 'mistral/mistral-nemo'
   | 'mistral/mistral-small'
+  | 'mistral/mixtral-8x22b-instruct'
+  | 'mistral/pixtral-12b'
+  | 'mistral/pixtral-large'
+  | 'moonshotai/kimi-k2'
+  | 'moonshotai/kimi-k2-0905'
+  | 'moonshotai/kimi-k2-thinking'
+  | 'moonshotai/kimi-k2-thinking-turbo'
+  | 'moonshotai/kimi-k2-turbo'
+  | 'moonshotai/kimi-k2.5'
+  | 'morph/morph-v3-fast'
+  | 'morph/morph-v3-large'
+  | 'nvidia/nemotron-3-nano-30b-a3b'
+  | 'nvidia/nemotron-nano-12b-v2-vl'
+  | 'nvidia/nemotron-nano-9b-v2'
+  | 'openai/gpt-3.5-turbo'
+  | 'openai/gpt-3.5-turbo-instruct'
+  | 'openai/gpt-4-turbo'
   | 'openai/gpt-4.1'
   | 'openai/gpt-4.1-mini'
   | 'openai/gpt-4.1-nano'
   | 'openai/gpt-4o'
   | 'openai/gpt-4o-mini'
+  | 'openai/gpt-4o-mini-search-preview'
+  | 'openai/gpt-5'
+  | 'openai/gpt-5-chat'
+  | 'openai/gpt-5-codex'
+  | 'openai/gpt-5-mini'
+  | 'openai/gpt-5-nano'
+  | 'openai/gpt-5-pro'
+  | 'openai/gpt-5.1-codex'
+  | 'openai/gpt-5.1-codex-max'
+  | 'openai/gpt-5.1-codex-mini'
+  | 'openai/gpt-5.1-instant'
+  | 'openai/gpt-5.1-thinking'
+  | 'openai/gpt-5.2'
+  | 'openai/gpt-5.2-chat'
+  | 'openai/gpt-5.2-codex'
+  | 'openai/gpt-5.2-pro'
+  | 'openai/gpt-5.3-chat'
+  | 'openai/gpt-5.3-codex'
+  | 'openai/gpt-5.4'
+  | 'openai/gpt-5.4-mini'
+  | 'openai/gpt-5.4-nano'
+  | 'openai/gpt-5.4-pro'
+  | 'openai/gpt-oss-120b'
+  | 'openai/gpt-oss-20b'
+  | 'openai/gpt-oss-safeguard-20b'
+  | 'openai/o1'
   | 'openai/o3'
+  | 'openai/o3-deep-research'
   | 'openai/o3-mini'
+  | 'openai/o3-pro'
   | 'openai/o4-mini'
   | 'perplexity/sonar'
   | 'perplexity/sonar-pro'
+  | 'perplexity/sonar-reasoning'
+  | 'perplexity/sonar-reasoning-pro'
+  | 'prime-intellect/intellect-3'
+  | 'xai/grok-2-vision'
   | 'xai/grok-3'
-  | 'xai/grok-3-mini';
+  | 'xai/grok-3-fast'
+  | 'xai/grok-3-mini'
+  | 'xai/grok-3-mini-fast'
+  | 'xai/grok-4'
+  | 'xai/grok-4-fast-non-reasoning'
+  | 'xai/grok-4-fast-reasoning'
+  | 'xai/grok-4.1-fast-non-reasoning'
+  | 'xai/grok-4.1-fast-reasoning'
+  | 'xai/grok-4.20-multi-agent-beta'
+  | 'xai/grok-4.20-non-reasoning-beta'
+  | 'xai/grok-4.20-reasoning-beta'
+  | 'xai/grok-code-fast-1'
+  | 'xiaomi/mimo-v2-flash'
+  | 'xiaomi/mimo-v2-pro'
+  | 'zai/glm-4.5'
+  | 'zai/glm-4.5-air'
+  | 'zai/glm-4.5v'
+  | 'zai/glm-4.6'
+  | 'zai/glm-4.6v'
+  | 'zai/glm-4.7'
+  | 'zai/glm-4.7-flash'
+  | 'zai/glm-4.7-flashx'
+  | 'zai/glm-5'
+  | 'zai/glm-5-turbo';
 
-// Pricing data from Vercel AI Gateway API
-// These are the per-token costs in USD
 export const VercelModels: SupportedModel[] = [
-  // Alibaba
   {
     model_id: 'alibaba/qwen-3-14b',
-    input_cost_per_token: 0.00000014,
-    output_cost_per_token: 0.00000014,
+    input_cost_per_token: 1.2e-7,
+    output_cost_per_token: 2.4e-7,
     provider: 'Vercel',
   },
   {
     model_id: 'alibaba/qwen-3-235b',
-    input_cost_per_token: 0.0000014,
-    output_cost_per_token: 0.0000014,
+    input_cost_per_token: 7.1e-8,
+    output_cost_per_token: 4.63e-7,
     provider: 'Vercel',
   },
   {
     model_id: 'alibaba/qwen-3-30b',
-    input_cost_per_token: 0.00000028,
-    output_cost_per_token: 0.00000028,
+    input_cost_per_token: 8e-8,
+    output_cost_per_token: 2.9e-7,
     provider: 'Vercel',
   },
   {
     model_id: 'alibaba/qwen-3-32b',
-    input_cost_per_token: 0.00000028,
-    output_cost_per_token: 0.00000028,
+    input_cost_per_token: 2.9e-7,
+    output_cost_per_token: 5.9e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-235b-a22b-thinking',
+    input_cost_per_token: 2.3e-7,
+    output_cost_per_token: 0.0000023,
     provider: 'Vercel',
   },
   {
     model_id: 'alibaba/qwen3-coder',
-    input_cost_per_token: 0.00000014,
-    output_cost_per_token: 0.0000006,
+    input_cost_per_token: 4e-7,
+    output_cost_per_token: 0.0000016,
     provider: 'Vercel',
   },
-  // Amazon
+  {
+    model_id: 'alibaba/qwen3-coder-30b-a3b',
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 6e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-coder-next',
+    input_cost_per_token: 5e-7,
+    output_cost_per_token: 0.0000012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-coder-plus',
+    input_cost_per_token: 0.000001,
+    output_cost_per_token: 0.000005,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-max',
+    input_cost_per_token: 0.0000012,
+    output_cost_per_token: 0.000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-max-preview',
+    input_cost_per_token: 0.0000012,
+    output_cost_per_token: 0.000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-max-thinking',
+    input_cost_per_token: 0.0000012,
+    output_cost_per_token: 0.000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-next-80b-a3b-instruct',
+    input_cost_per_token: 9e-8,
+    output_cost_per_token: 0.0000011,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-next-80b-a3b-thinking',
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 0.0000012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-vl-instruct',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 8.8e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-vl-thinking',
+    input_cost_per_token: 2.2e-7,
+    output_cost_per_token: 8.8e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3.5-flash',
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 4e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3.5-plus',
+    input_cost_per_token: 4e-7,
+    output_cost_per_token: 0.0000024,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'amazon/nova-2-lite',
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 0.0000025,
+    provider: 'Vercel',
+  },
   {
     model_id: 'amazon/nova-lite',
-    input_cost_per_token: 0.00000006,
-    output_cost_per_token: 0.00000024,
+    input_cost_per_token: 6e-8,
+    output_cost_per_token: 2.4e-7,
     provider: 'Vercel',
   },
   {
     model_id: 'amazon/nova-micro',
-    input_cost_per_token: 0.000000035,
-    output_cost_per_token: 0.00000014,
+    input_cost_per_token: 3.5e-8,
+    output_cost_per_token: 1.4e-7,
     provider: 'Vercel',
   },
   {
     model_id: 'amazon/nova-pro',
-    input_cost_per_token: 0.0000008,
+    input_cost_per_token: 8e-7,
     output_cost_per_token: 0.0000032,
     provider: 'Vercel',
   },
-  // Anthropic
   {
     model_id: 'anthropic/claude-3-haiku',
-    input_cost_per_token: 0.00000025,
+    input_cost_per_token: 2.5e-7,
     output_cost_per_token: 0.00000125,
     provider: 'Vercel',
   },
@@ -118,12 +326,18 @@ export const VercelModels: SupportedModel[] = [
   },
   {
     model_id: 'anthropic/claude-3.5-haiku',
-    input_cost_per_token: 0.0000008,
+    input_cost_per_token: 8e-7,
     output_cost_per_token: 0.000004,
     provider: 'Vercel',
   },
   {
     model_id: 'anthropic/claude-3.5-sonnet',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-3.5-sonnet-20240620',
     input_cost_per_token: 0.000003,
     output_cost_per_token: 0.000015,
     provider: 'Vercel',
@@ -135,9 +349,33 @@ export const VercelModels: SupportedModel[] = [
     provider: 'Vercel',
   },
   {
+    model_id: 'anthropic/claude-haiku-4.5',
+    input_cost_per_token: 0.000001,
+    output_cost_per_token: 0.000005,
+    provider: 'Vercel',
+  },
+  {
     model_id: 'anthropic/claude-opus-4',
     input_cost_per_token: 0.000015,
     output_cost_per_token: 0.000075,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-opus-4.1',
+    input_cost_per_token: 0.000015,
+    output_cost_per_token: 0.000075,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-opus-4.5',
+    input_cost_per_token: 0.000005,
+    output_cost_per_token: 0.000025,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-opus-4.6',
+    input_cost_per_token: 0.000005,
+    output_cost_per_token: 0.000025,
     provider: 'Vercel',
   },
   {
@@ -146,7 +384,42 @@ export const VercelModels: SupportedModel[] = [
     output_cost_per_token: 0.000015,
     provider: 'Vercel',
   },
-  // Cohere
+  {
+    model_id: 'anthropic/claude-sonnet-4.5',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-sonnet-4.6',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'arcee-ai/trinity-large-preview',
+    input_cost_per_token: 2.5e-7,
+    output_cost_per_token: 0.000001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'arcee-ai/trinity-mini',
+    input_cost_per_token: 4.5e-8,
+    output_cost_per_token: 1.5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'bytedance/seed-1.6',
+    input_cost_per_token: 2.5e-7,
+    output_cost_per_token: 0.000002,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'bytedance/seed-1.8',
+    input_cost_per_token: 2.5e-7,
+    output_cost_per_token: 0.000002,
+    provider: 'Vercel',
+  },
   {
     model_id: 'cohere/command-a',
     input_cost_per_token: 0.0000025,
@@ -154,53 +427,69 @@ export const VercelModels: SupportedModel[] = [
     provider: 'Vercel',
   },
   {
-    model_id: 'cohere/command-r',
-    input_cost_per_token: 0.00000015,
-    output_cost_per_token: 0.0000006,
-    provider: 'Vercel',
-  },
-  {
-    model_id: 'cohere/command-r-plus',
-    input_cost_per_token: 0.0000025,
-    output_cost_per_token: 0.00001,
-    provider: 'Vercel',
-  },
-  // DeepSeek
-  {
     model_id: 'deepseek/deepseek-r1',
-    input_cost_per_token: 0.00000055,
-    output_cost_per_token: 0.00000219,
+    input_cost_per_token: 0.00000135,
+    output_cost_per_token: 0.0000054,
     provider: 'Vercel',
   },
   {
     model_id: 'deepseek/deepseek-v3',
-    input_cost_per_token: 0.00000027,
-    output_cost_per_token: 0.0000011,
+    input_cost_per_token: 7.7e-7,
+    output_cost_per_token: 7.7e-7,
     provider: 'Vercel',
   },
   {
     model_id: 'deepseek/deepseek-v3.1',
-    input_cost_per_token: 0.00000027,
-    output_cost_per_token: 0.0000011,
+    input_cost_per_token: 5e-7,
+    output_cost_per_token: 0.0000015,
     provider: 'Vercel',
   },
-  // Google
+  {
+    model_id: 'deepseek/deepseek-v3.1-terminus',
+    input_cost_per_token: 2.7e-7,
+    output_cost_per_token: 0.000001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'deepseek/deepseek-v3.2',
+    input_cost_per_token: 2.8e-7,
+    output_cost_per_token: 4.2e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'deepseek/deepseek-v3.2-thinking',
+    input_cost_per_token: 2.8e-7,
+    output_cost_per_token: 4.2e-7,
+    provider: 'Vercel',
+  },
   {
     model_id: 'google/gemini-2.0-flash',
-    input_cost_per_token: 0.0000001,
-    output_cost_per_token: 0.0000004,
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 6e-7,
     provider: 'Vercel',
   },
   {
     model_id: 'google/gemini-2.0-flash-lite',
-    input_cost_per_token: 0.000000075,
-    output_cost_per_token: 0.0000003,
+    input_cost_per_token: 7.5e-8,
+    output_cost_per_token: 3e-7,
     provider: 'Vercel',
   },
   {
     model_id: 'google/gemini-2.5-flash',
-    input_cost_per_token: 0.00000015,
-    output_cost_per_token: 0.0000006,
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 0.0000025,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'google/gemini-2.5-flash-image',
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 0.0000025,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'google/gemini-2.5-flash-lite',
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 4e-7,
     provider: 'Vercel',
   },
   {
@@ -209,51 +498,342 @@ export const VercelModels: SupportedModel[] = [
     output_cost_per_token: 0.00001,
     provider: 'Vercel',
   },
-  // Meta
   {
-    model_id: 'meta/llama-3.1-70b',
-    input_cost_per_token: 0.00000088,
-    output_cost_per_token: 0.00000088,
+    model_id: 'google/gemini-3-flash',
+    input_cost_per_token: 5e-7,
+    output_cost_per_token: 0.000003,
     provider: 'Vercel',
   },
   {
-    model_id: 'meta/llama-3.1-8b',
-    input_cost_per_token: 0.00000018,
-    output_cost_per_token: 0.00000018,
+    model_id: 'google/gemini-3-pro-image',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000012,
     provider: 'Vercel',
   },
   {
-    model_id: 'meta/llama-3.3-70b',
-    input_cost_per_token: 0.00000088,
-    output_cost_per_token: 0.00000088,
+    model_id: 'google/gemini-3-pro-preview',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000012,
     provider: 'Vercel',
   },
   {
-    model_id: 'meta/llama-4-maverick',
-    input_cost_per_token: 0.00000025,
+    model_id: 'google/gemini-3.1-flash-image-preview',
+    input_cost_per_token: 5e-7,
+    output_cost_per_token: 0.000003,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'google/gemini-3.1-flash-lite-preview',
+    input_cost_per_token: 2.5e-7,
+    output_cost_per_token: 0.0000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'google/gemini-3.1-pro-preview',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'inception/mercury-2',
+    input_cost_per_token: 2.5e-7,
+    output_cost_per_token: 7.5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'inception/mercury-coder-small',
+    input_cost_per_token: 2.5e-7,
     output_cost_per_token: 0.000001,
     provider: 'Vercel',
   },
   {
-    model_id: 'meta/llama-4-scout',
-    input_cost_per_token: 0.00000015,
-    output_cost_per_token: 0.0000006,
+    model_id: 'kwaipilot/kat-coder-pro-v1',
+    input_cost_per_token: 3e-8,
+    output_cost_per_token: 0.0000012,
     provider: 'Vercel',
   },
-  // Mistral
   {
-    model_id: 'mistral/mistral-large',
+    model_id: 'meituan/longcat-flash-thinking',
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 0.0000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-3.1-70b',
+    input_cost_per_token: 7.2e-7,
+    output_cost_per_token: 7.2e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-3.1-8b',
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 1e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-3.2-11b',
+    input_cost_per_token: 1.6e-7,
+    output_cost_per_token: 1.6e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-3.2-1b',
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 1e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-3.2-3b',
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 1.5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-3.2-90b',
+    input_cost_per_token: 7.2e-7,
+    output_cost_per_token: 7.2e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-3.3-70b',
+    input_cost_per_token: 7.2e-7,
+    output_cost_per_token: 7.2e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-4-maverick',
+    input_cost_per_token: 2.4e-7,
+    output_cost_per_token: 9.7e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-4-scout',
+    input_cost_per_token: 1.7e-7,
+    output_cost_per_token: 6.6e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'minimax/minimax-m2',
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 0.0000012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'minimax/minimax-m2.1',
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 0.0000012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'minimax/minimax-m2.1-lightning',
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 0.0000024,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'minimax/minimax-m2.5',
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 0.0000012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'minimax/minimax-m2.5-highspeed',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.0000024,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'minimax/minimax-m2.7',
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 0.0000012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'minimax/minimax-m2.7-highspeed',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.0000024,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/codestral',
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 9e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/devstral-2',
+    input_cost_per_token: 4e-7,
+    output_cost_per_token: 0.000002,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/devstral-small',
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 3e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/devstral-small-2',
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 3e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/magistral-medium',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000005,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/magistral-small',
+    input_cost_per_token: 5e-7,
+    output_cost_per_token: 0.0000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/ministral-14b',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 2e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/ministral-3b',
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 1e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/ministral-8b',
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 1.5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/mistral-large-3',
+    input_cost_per_token: 5e-7,
+    output_cost_per_token: 0.0000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/mistral-medium',
+    input_cost_per_token: 4e-7,
+    output_cost_per_token: 0.000002,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/mistral-nemo',
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 1.5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/mistral-small',
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 3e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/mixtral-8x22b-instruct',
+    input_cost_per_token: 0.0000012,
+    output_cost_per_token: 0.0000012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/pixtral-12b',
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 1.5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/pixtral-large',
     input_cost_per_token: 0.000002,
     output_cost_per_token: 0.000006,
     provider: 'Vercel',
   },
   {
-    model_id: 'mistral/mistral-small',
-    input_cost_per_token: 0.0000001,
-    output_cost_per_token: 0.0000003,
+    model_id: 'moonshotai/kimi-k2',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.0000025,
     provider: 'Vercel',
   },
-  // OpenAI
+  {
+    model_id: 'moonshotai/kimi-k2-0905',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.0000025,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'moonshotai/kimi-k2-thinking',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.0000025,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'moonshotai/kimi-k2-thinking-turbo',
+    input_cost_per_token: 0.00000115,
+    output_cost_per_token: 0.000008,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'moonshotai/kimi-k2-turbo',
+    input_cost_per_token: 0.00000115,
+    output_cost_per_token: 0.000008,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'moonshotai/kimi-k2.5',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.000003,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'morph/morph-v3-fast',
+    input_cost_per_token: 8e-7,
+    output_cost_per_token: 0.0000012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'morph/morph-v3-large',
+    input_cost_per_token: 9e-7,
+    output_cost_per_token: 0.0000019,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'nvidia/nemotron-3-nano-30b-a3b',
+    input_cost_per_token: 5e-8,
+    output_cost_per_token: 2.4e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'nvidia/nemotron-nano-12b-v2-vl',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 6e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'nvidia/nemotron-nano-9b-v2',
+    input_cost_per_token: 6e-8,
+    output_cost_per_token: 2.3e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-3.5-turbo',
+    input_cost_per_token: 5e-7,
+    output_cost_per_token: 0.0000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-3.5-turbo-instruct',
+    input_cost_per_token: 0.0000015,
+    output_cost_per_token: 0.000002,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-4-turbo',
+    input_cost_per_token: 0.00001,
+    output_cost_per_token: 0.00003,
+    provider: 'Vercel',
+  },
   {
     model_id: 'openai/gpt-4.1',
     input_cost_per_token: 0.000002,
@@ -262,14 +842,14 @@ export const VercelModels: SupportedModel[] = [
   },
   {
     model_id: 'openai/gpt-4.1-mini',
-    input_cost_per_token: 0.0000004,
+    input_cost_per_token: 4e-7,
     output_cost_per_token: 0.0000016,
     provider: 'Vercel',
   },
   {
     model_id: 'openai/gpt-4.1-nano',
-    input_cost_per_token: 0.0000001,
-    output_cost_per_token: 0.0000004,
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 4e-7,
     provider: 'Vercel',
   },
   {
@@ -280,12 +860,174 @@ export const VercelModels: SupportedModel[] = [
   },
   {
     model_id: 'openai/gpt-4o-mini',
-    input_cost_per_token: 0.00000015,
-    output_cost_per_token: 0.0000006,
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 6e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-4o-mini-search-preview',
+    input_cost_per_token: 1.5e-7,
+    output_cost_per_token: 6e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5',
+    input_cost_per_token: 0.00000125,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5-chat',
+    input_cost_per_token: 0.00000125,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5-codex',
+    input_cost_per_token: 0.00000125,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5-mini',
+    input_cost_per_token: 2.5e-7,
+    output_cost_per_token: 0.000002,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5-nano',
+    input_cost_per_token: 5e-8,
+    output_cost_per_token: 4e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5-pro',
+    input_cost_per_token: 0.000015,
+    output_cost_per_token: 0.00012,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.1-codex',
+    input_cost_per_token: 0.00000125,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.1-codex-max',
+    input_cost_per_token: 0.00000125,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.1-codex-mini',
+    input_cost_per_token: 2.5e-7,
+    output_cost_per_token: 0.000002,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.1-instant',
+    input_cost_per_token: 0.00000125,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.1-thinking',
+    input_cost_per_token: 0.00000125,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.2',
+    input_cost_per_token: 0.00000175,
+    output_cost_per_token: 0.000014,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.2-chat',
+    input_cost_per_token: 0.00000175,
+    output_cost_per_token: 0.000014,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.2-codex',
+    input_cost_per_token: 0.00000175,
+    output_cost_per_token: 0.000014,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.2-pro',
+    input_cost_per_token: 0.000021,
+    output_cost_per_token: 0.000168,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.3-chat',
+    input_cost_per_token: 0.00000175,
+    output_cost_per_token: 0.000014,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.3-codex',
+    input_cost_per_token: 0.00000175,
+    output_cost_per_token: 0.000014,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.4',
+    input_cost_per_token: 0.0000025,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.4-mini',
+    input_cost_per_token: 7.5e-7,
+    output_cost_per_token: 0.0000045,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.4-nano',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 0.00000125,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-5.4-pro',
+    input_cost_per_token: 0.00003,
+    output_cost_per_token: 0.00018,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-oss-120b',
+    input_cost_per_token: 3.5e-7,
+    output_cost_per_token: 7.5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-oss-20b',
+    input_cost_per_token: 7e-8,
+    output_cost_per_token: 3e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-oss-safeguard-20b',
+    input_cost_per_token: 7.5e-8,
+    output_cost_per_token: 3e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/o1',
+    input_cost_per_token: 0.000015,
+    output_cost_per_token: 0.00006,
     provider: 'Vercel',
   },
   {
     model_id: 'openai/o3',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000008,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/o3-deep-research',
     input_cost_per_token: 0.00001,
     output_cost_per_token: 0.00004,
     provider: 'Vercel',
@@ -297,12 +1039,17 @@ export const VercelModels: SupportedModel[] = [
     provider: 'Vercel',
   },
   {
+    model_id: 'openai/o3-pro',
+    input_cost_per_token: 0.00002,
+    output_cost_per_token: 0.00008,
+    provider: 'Vercel',
+  },
+  {
     model_id: 'openai/o4-mini',
     input_cost_per_token: 0.0000011,
     output_cost_per_token: 0.0000044,
     provider: 'Vercel',
   },
-  // Perplexity
   {
     model_id: 'perplexity/sonar',
     input_cost_per_token: 0.000001,
@@ -315,7 +1062,30 @@ export const VercelModels: SupportedModel[] = [
     output_cost_per_token: 0.000015,
     provider: 'Vercel',
   },
-  // xAI
+  {
+    model_id: 'perplexity/sonar-reasoning',
+    input_cost_per_token: 0.000001,
+    output_cost_per_token: 0.000005,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'perplexity/sonar-reasoning-pro',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000008,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'prime-intellect/intellect-3',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 0.0000011,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-2-vision',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
   {
     model_id: 'xai/grok-3',
     input_cost_per_token: 0.000003,
@@ -323,9 +1093,147 @@ export const VercelModels: SupportedModel[] = [
     provider: 'Vercel',
   },
   {
+    model_id: 'xai/grok-3-fast',
+    input_cost_per_token: 0.000005,
+    output_cost_per_token: 0.000025,
+    provider: 'Vercel',
+  },
+  {
     model_id: 'xai/grok-3-mini',
-    input_cost_per_token: 0.0000003,
-    output_cost_per_token: 0.0000005,
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-3-mini-fast',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.000004,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-4',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-4-fast-non-reasoning',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-4-fast-reasoning',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-4.1-fast-non-reasoning',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-4.1-fast-reasoning',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 5e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-4.20-multi-agent-beta',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-4.20-non-reasoning-beta',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-4.20-reasoning-beta',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-code-fast-1',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 0.0000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xiaomi/mimo-v2-flash',
+    input_cost_per_token: 1e-7,
+    output_cost_per_token: 3e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xiaomi/mimo-v2-pro',
+    input_cost_per_token: 0.000001,
+    output_cost_per_token: 0.000003,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-4.5',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.0000022,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-4.5-air',
+    input_cost_per_token: 2e-7,
+    output_cost_per_token: 0.0000011,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-4.5v',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.0000018,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-4.6',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.0000022,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-4.6v',
+    input_cost_per_token: 3e-7,
+    output_cost_per_token: 9e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-4.7',
+    input_cost_per_token: 6e-7,
+    output_cost_per_token: 0.0000022,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-4.7-flash',
+    input_cost_per_token: 7e-8,
+    output_cost_per_token: 4e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-4.7-flashx',
+    input_cost_per_token: 6e-8,
+    output_cost_per_token: 4e-7,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-5',
+    input_cost_per_token: 0.000001,
+    output_cost_per_token: 0.0000032,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'zai/glm-5-turbo',
+    input_cost_per_token: 0.0000012,
+    output_cost_per_token: 0.000004,
     provider: 'Vercel',
   },
 ];

--- a/packages/sdk/ts/src/supported-models/chat/vercel.ts
+++ b/packages/sdk/ts/src/supported-models/chat/vercel.ts
@@ -1,0 +1,331 @@
+import { SupportedModel } from '../types';
+
+// Vercel AI Gateway model IDs
+// Models accessed through the Vercel AI Gateway use the format: provider/model-id
+// Pricing sourced from: Vercel AI Gateway API (gateway.getAvailableModels())
+// Last updated: 2026-03-20
+export type VercelModel =
+  | 'alibaba/qwen-3-14b'
+  | 'alibaba/qwen-3-235b'
+  | 'alibaba/qwen-3-30b'
+  | 'alibaba/qwen-3-32b'
+  | 'alibaba/qwen3-coder'
+  | 'amazon/nova-lite'
+  | 'amazon/nova-micro'
+  | 'amazon/nova-pro'
+  | 'anthropic/claude-3-haiku'
+  | 'anthropic/claude-3-opus'
+  | 'anthropic/claude-3.5-haiku'
+  | 'anthropic/claude-3.5-sonnet'
+  | 'anthropic/claude-3.7-sonnet'
+  | 'anthropic/claude-opus-4'
+  | 'anthropic/claude-sonnet-4'
+  | 'cohere/command-a'
+  | 'cohere/command-r'
+  | 'cohere/command-r-plus'
+  | 'deepseek/deepseek-r1'
+  | 'deepseek/deepseek-v3'
+  | 'deepseek/deepseek-v3.1'
+  | 'google/gemini-2.0-flash'
+  | 'google/gemini-2.0-flash-lite'
+  | 'google/gemini-2.5-flash'
+  | 'google/gemini-2.5-pro'
+  | 'meta/llama-3.1-70b'
+  | 'meta/llama-3.1-8b'
+  | 'meta/llama-3.3-70b'
+  | 'meta/llama-4-maverick'
+  | 'meta/llama-4-scout'
+  | 'mistral/mistral-large'
+  | 'mistral/mistral-small'
+  | 'openai/gpt-4.1'
+  | 'openai/gpt-4.1-mini'
+  | 'openai/gpt-4.1-nano'
+  | 'openai/gpt-4o'
+  | 'openai/gpt-4o-mini'
+  | 'openai/o3'
+  | 'openai/o3-mini'
+  | 'openai/o4-mini'
+  | 'perplexity/sonar'
+  | 'perplexity/sonar-pro'
+  | 'xai/grok-3'
+  | 'xai/grok-3-mini';
+
+// Pricing data from Vercel AI Gateway API
+// These are the per-token costs in USD
+export const VercelModels: SupportedModel[] = [
+  // Alibaba
+  {
+    model_id: 'alibaba/qwen-3-14b',
+    input_cost_per_token: 0.00000014,
+    output_cost_per_token: 0.00000014,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen-3-235b',
+    input_cost_per_token: 0.0000014,
+    output_cost_per_token: 0.0000014,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen-3-30b',
+    input_cost_per_token: 0.00000028,
+    output_cost_per_token: 0.00000028,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen-3-32b',
+    input_cost_per_token: 0.00000028,
+    output_cost_per_token: 0.00000028,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'alibaba/qwen3-coder',
+    input_cost_per_token: 0.00000014,
+    output_cost_per_token: 0.0000006,
+    provider: 'Vercel',
+  },
+  // Amazon
+  {
+    model_id: 'amazon/nova-lite',
+    input_cost_per_token: 0.00000006,
+    output_cost_per_token: 0.00000024,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'amazon/nova-micro',
+    input_cost_per_token: 0.000000035,
+    output_cost_per_token: 0.00000014,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'amazon/nova-pro',
+    input_cost_per_token: 0.0000008,
+    output_cost_per_token: 0.0000032,
+    provider: 'Vercel',
+  },
+  // Anthropic
+  {
+    model_id: 'anthropic/claude-3-haiku',
+    input_cost_per_token: 0.00000025,
+    output_cost_per_token: 0.00000125,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-3-opus',
+    input_cost_per_token: 0.000015,
+    output_cost_per_token: 0.000075,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-3.5-haiku',
+    input_cost_per_token: 0.0000008,
+    output_cost_per_token: 0.000004,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-3.5-sonnet',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-3.7-sonnet',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-opus-4',
+    input_cost_per_token: 0.000015,
+    output_cost_per_token: 0.000075,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'anthropic/claude-sonnet-4',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  // Cohere
+  {
+    model_id: 'cohere/command-a',
+    input_cost_per_token: 0.0000025,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'cohere/command-r',
+    input_cost_per_token: 0.00000015,
+    output_cost_per_token: 0.0000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'cohere/command-r-plus',
+    input_cost_per_token: 0.0000025,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  // DeepSeek
+  {
+    model_id: 'deepseek/deepseek-r1',
+    input_cost_per_token: 0.00000055,
+    output_cost_per_token: 0.00000219,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'deepseek/deepseek-v3',
+    input_cost_per_token: 0.00000027,
+    output_cost_per_token: 0.0000011,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'deepseek/deepseek-v3.1',
+    input_cost_per_token: 0.00000027,
+    output_cost_per_token: 0.0000011,
+    provider: 'Vercel',
+  },
+  // Google
+  {
+    model_id: 'google/gemini-2.0-flash',
+    input_cost_per_token: 0.0000001,
+    output_cost_per_token: 0.0000004,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'google/gemini-2.0-flash-lite',
+    input_cost_per_token: 0.000000075,
+    output_cost_per_token: 0.0000003,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'google/gemini-2.5-flash',
+    input_cost_per_token: 0.00000015,
+    output_cost_per_token: 0.0000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'google/gemini-2.5-pro',
+    input_cost_per_token: 0.00000125,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  // Meta
+  {
+    model_id: 'meta/llama-3.1-70b',
+    input_cost_per_token: 0.00000088,
+    output_cost_per_token: 0.00000088,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-3.1-8b',
+    input_cost_per_token: 0.00000018,
+    output_cost_per_token: 0.00000018,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-3.3-70b',
+    input_cost_per_token: 0.00000088,
+    output_cost_per_token: 0.00000088,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-4-maverick',
+    input_cost_per_token: 0.00000025,
+    output_cost_per_token: 0.000001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'meta/llama-4-scout',
+    input_cost_per_token: 0.00000015,
+    output_cost_per_token: 0.0000006,
+    provider: 'Vercel',
+  },
+  // Mistral
+  {
+    model_id: 'mistral/mistral-large',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'mistral/mistral-small',
+    input_cost_per_token: 0.0000001,
+    output_cost_per_token: 0.0000003,
+    provider: 'Vercel',
+  },
+  // OpenAI
+  {
+    model_id: 'openai/gpt-4.1',
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.000008,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-4.1-mini',
+    input_cost_per_token: 0.0000004,
+    output_cost_per_token: 0.0000016,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-4.1-nano',
+    input_cost_per_token: 0.0000001,
+    output_cost_per_token: 0.0000004,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-4o',
+    input_cost_per_token: 0.0000025,
+    output_cost_per_token: 0.00001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/gpt-4o-mini',
+    input_cost_per_token: 0.00000015,
+    output_cost_per_token: 0.0000006,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/o3',
+    input_cost_per_token: 0.00001,
+    output_cost_per_token: 0.00004,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/o3-mini',
+    input_cost_per_token: 0.0000011,
+    output_cost_per_token: 0.0000044,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'openai/o4-mini',
+    input_cost_per_token: 0.0000011,
+    output_cost_per_token: 0.0000044,
+    provider: 'Vercel',
+  },
+  // Perplexity
+  {
+    model_id: 'perplexity/sonar',
+    input_cost_per_token: 0.000001,
+    output_cost_per_token: 0.000001,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'perplexity/sonar-pro',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  // xAI
+  {
+    model_id: 'xai/grok-3',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Vercel',
+  },
+  {
+    model_id: 'xai/grok-3-mini',
+    input_cost_per_token: 0.0000003,
+    output_cost_per_token: 0.0000005,
+    provider: 'Vercel',
+  },
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 10.1.5(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))
+        version: 2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-prefer-arrow:
         specifier: ^1.2.3
         version: 1.2.3(eslint@9.35.0(jiti@2.5.1))
@@ -1197,6 +1197,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: 2.0.17
         version: 2.0.17(zod@4.1.11)
+      '@ai-sdk/gateway':
+        specifier: ^1.0.12
+        version: 1.0.24(zod@4.1.11)
       '@ai-sdk/google':
         specifier: 2.0.14
         version: 2.0.14(zod@4.1.11)
@@ -1216,9 +1219,6 @@ importers:
         specifier: 5.0.47
         version: 5.0.47(zod@4.1.11)
     devDependencies:
-      '@ai-sdk/gateway':
-        specifier: ^1.0.12
-        version: 1.0.24(zod@4.1.11)
       '@types/node':
         specifier: ^24.3.1
         version: 24.3.1
@@ -21903,8 +21903,8 @@ snapshots:
       '@typescript-eslint/parser': 8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react: 7.37.5(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.35.0(jiti@2.5.1))
@@ -21962,21 +21962,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.35.0(jiti@2.5.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.1
-      eslint: 9.35.0(jiti@2.5.1)
-      get-tsconfig: 4.10.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.9.0
-    optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
@@ -21985,17 +21970,6 @@ snapshots:
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.35.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -22011,35 +21985,6 @@ snapshots:
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.34.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Adds the Vercel AI Gateway as a new provider for the Echo platform, enabling access to 45+ models from multiple providers (OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek, Cohere, Perplexity, xAI, Amazon, Alibaba) through a single unified gateway.

### SDK Changes
- **`src/providers/vercel.ts`** — `createEchoVercelAIGateway()` provider function using `@ai-sdk/gateway`
- **`src/supported-models/chat/vercel.ts`** — Model definitions with pricing data from the gateway API
- **`scripts/update-vercel-models.ts`** — Automated script to fetch latest models and pricing
- Moved `@ai-sdk/gateway` from devDependencies to dependencies
- Added `update-models:vercel` npm script and included in `update-all-models`

### Server Changes
- **`VercelAIGatewayProvider.ts`** — Server-side provider using OpenAI-compatible SSE format
- **`ProviderType.ts`** — Added `VERCEL_AI_GATEWAY` enum value
- **`ProviderFactory.ts`** — Wired Vercel provider into model routing
- **`AccountingService.ts`** — Added VercelModels to cost calculation
- **`env.ts`** — Added `VERCEL_AI_GATEWAY_API_KEY` environment variable

### How It Works
The Vercel AI Gateway acts as a unified proxy to multiple AI providers. Model IDs use the `provider/model` format (e.g., `openai/gpt-4o`, `anthropic/claude-sonnet-4`). The gateway handles provider-specific auth and formatting, returning OpenAI-compatible responses — so the server-side provider reuses the existing GPT SSE parsing logic.

### Testing
- All 27 existing SDK tests pass
- SDK and server both build cleanly

Closes #573