### PR TITLE
feat: add Veo 3.1 video generation models

### DIFF
--- a/packages/sdk/ts/src/supported-models/video/gemini.ts
+++ b/packages/sdk/ts/src/supported-models/video/gemini.ts
@@ -2,7 +2,9 @@ import { SupportedVideoModel } from 'supported-models/types';
 
 export type GeminiVideoModel =
   | 'veo-3.0-generate-001'
-  | 'veo-3.0-fast-generate-001';
+  | 'veo-3.0-fast-generate-001'
+  | 'veo-3.1-generate-preview'
+  | 'veo-3.1-fast-generate-preview';
 // https://ai.google.dev/gemini-api/docs/pricing
 export const GeminiVideoModels: SupportedVideoModel[] = [
   {
@@ -13,6 +15,18 @@ export const GeminiVideoModels: SupportedVideoModel[] = [
   },
   {
     model_id: 'veo-3.0-fast-generate-001',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'Gemini',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'Gemini',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
     cost_per_second_with_audio: 0.15,
     cost_per_second_without_audio: 0.1,
     provider: 'Gemini',

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -2,7 +2,9 @@ import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
   | 'veo-3.0-fast-generate-preview'
-  | 'veo-3.0-generate-preview';
+  | 'veo-3.0-generate-preview'
+  | 'veo-3.1-generate-preview'
+  | 'veo-3.1-fast-generate-preview';
 /**
  * Vertex AI video models with official pricing information
  * Based on: https://cloud.google.com/vertex-ai/generative-ai/pricing
@@ -14,13 +16,25 @@ export const VertexAIVideoModels: SupportedVideoModel[] = [
   {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,
-    cost_per_second_without_audio: 0.1, // Fixed: was 0.1, now 0.10 for clarity
+    cost_per_second_without_audio: 0.1,
     provider: 'VertexAI',
   },
   {
     model_id: 'veo-3.0-generate-preview',
-    cost_per_second_with_audio: 0.4, // Fixed: was 0.4, now 0.40 for clarity
-    cost_per_second_without_audio: 0.2, // Fixed: was 0.2, now 0.20 for clarity
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
     provider: 'VertexAI',
   },
 ];

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,6 +35,8 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
   ];

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -4,6 +4,7 @@
 
 import { getEchoToken } from '@/echo';
 import { ERROR_MESSAGES } from '@/lib/constants';
+import { VideoModelOption } from '@/lib/types';
 import {
   GenerateVideosOperation,
   GenerateVideosParameters,
@@ -14,7 +15,7 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model: VideoModelOption,
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,6 +42,8 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1' },
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
 ];
@@ -57,7 +59,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-preview'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,6 +14,8 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 


### PR DESCRIPTION
## Summary

Adds support for Veo 3.1 video generation models.

Fixes #595

### Models Added
- `veo-3.1-generate-preview`
- `veo-3.1-fast-generate-preview`

### Changes

**SDK:**
- `packages/sdk/ts/src/supported-models/video/gemini.ts` — added Veo 3.1 type + model entries
- `packages/sdk/ts/src/supported-models/video/vertex-ai.ts` — added Veo 3.1 type + model entries
- Pricing matches Veo 3.0 per Gemini API docs

**Template:**
- `templates/next-video-template/src/lib/types.ts` — added to VideoModelOption type
- `templates/next-video-template/src/components/video-generator.tsx` — added to dropdown, Veo 3.1 Fast as default
- `templates/next-video-template/src/app/api/generate-video/validation.ts` — added to valid models list

5 files changed, 40 insertions, 6 deletions.