### PR TITLE
fix: Support Veo 3.1 in the veo provider

### DIFF
--- a/packages/router/src/providers/google/veo.ts
+++ b/packages/router/src/providers/google/veo.ts
@@ -1,0 +1,8 @@
+export const GOOGLE_VEO_MODELS = [
+  'veo-3.1-generate-preview',
+  'veo-3.1-fast-generate-preview',
+  'veo-generate-preview',
+  'veo-fast-generate-preview',
+];
+
+export const GOOGLE_VEO_MODEL_DEFAULT = 'veo-3.1-generate-preview';

--- a/templates/react-video/src/App.tsx
+++ b/templates/react-video/src/App.tsx
@@ -1,0 +1,9 @@
+const VEO_MODELS = [
+  'veo-3.1-generate-preview',
+  'veo-3.1-fast-generate-preview',
+  'veo-generate-preview',
+  'veo-fast-generate-preview',
+];
+
+function App() {
+  const [model, setModel] = useState<string>('veo-3.1-generate-preview'); // Default model


### PR DESCRIPTION
Closes #595

## What changed
This fix adds support for Veo 3.1 models to the Echo router's Veo provider and updates the React video template to include these new models as default options.

## Files modified
- `packages/router/src/providers/google/veo.ts`
- `templates/react-video/src/App.tsx`

---
*Draft PR — please review before merging.*