### PR TITLE
fix: Add .cursor/rules/echo_rules.mdc to echo-start templates

### DIFF
--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
+globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+---
+
+# Echo API Route Guidelines
+
+This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+
+## Defining Echo Handlers
+
+Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+
+Example `route.ts` for an echo endpoint:

--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,14 +1,67 @@
 ---
-description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
-globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+description: Guidelines for the Echo assistant-ui template — multi-provider AI (OpenAI, Anthropic, Google), streaming chat, and tool calling via the AI SDK.
+globs: **/*.ts,**/*.tsx
 ---
 
-# Echo API Route Guidelines
+# Echo Assistant-UI Guidelines
 
-This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+This template exposes multiple AI providers through a single `echo.ts` at the project root.
 
-## Defining Echo Handlers
+## Echo Setup (`echo.ts`)
 
-Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+```ts
+import Echo from '@merit-systems/echo-next-sdk';
+const echo = Echo({ appId: process.env.NEXT_PUBLIC_ECHO_APP_ID ?? 'ECHO_APP_ID' });
+export const { getUser, isSignedIn, openai, anthropic, google } = echo;
+export default echo.handlers;
+```
 
-Example `route.ts` for an echo endpoint:
+- Import `openai`, `anthropic`, or `google` from `@/echo` — never directly from provider SDKs.
+- The default export `echo.handlers` mounts to `app/api/echo/[...path]/route.ts`.
+
+## Echo Catch-All Route
+
+```ts
+// app/api/echo/[...path]/route.ts
+import handlers from '@/echo';
+export const { GET, POST } = handlers;
+```
+
+## Chat Route with Tools
+
+```ts
+// app/api/chat/route.ts
+import { openai } from '@/echo';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const result = streamText({
+    model: openai('gpt-4o'),
+    messages,
+    tools: {
+      lookup: tool({
+        description: 'Look up structured data',
+        parameters: z.object({ query: z.string() }),
+        execute: async ({ query }) => ({ data: `result for ${query}` }),
+      }),
+    },
+  });
+  return result.toDataStreamResponse();
+}
+```
+
+## Provider Selection
+
+| Use case | Client |
+|----------|--------|
+| Tool / function calling | `openai('gpt-4o')` |
+| Long context, document analysis | `anthropic('claude-3-5-sonnet-20241022')` |
+| Vision / multimodal | `google('gemini-2.0-flash')` |
+
+## Environment Variables
+
+```
+NEXT_PUBLIC_ECHO_APP_ID=your-echo-app-id
+```

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
+globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+---
+
+# Echo API Route Guidelines
+
+This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+
+## Defining Echo Handlers
+
+Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+
+Example `route.ts` for an echo endpoint:

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,14 +1,70 @@
 ---
-description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
-globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+description: Guidelines for the Echo authjs template — Next-Auth session management, authenticated API routes, and echo handler setup.
+globs: **/*.ts,**/*.tsx
 ---
 
-# Echo API Route Guidelines
+# Echo AuthJS Guidelines
 
-This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+This template integrates Next-Auth (Auth.js) with Echo for user-authenticated AI API routes.
 
-## Defining Echo Handlers
+## Echo Client (`src/lib/echo-client.ts`)
 
-Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+The Echo client is created once and reused across the app:
 
-Example `route.ts` for an echo endpoint:
+```ts
+import Echo from '@merit-systems/echo-next-sdk';
+export const echo = Echo({ appId: process.env.NEXT_PUBLIC_ECHO_APP_ID! });
+export const { handlers, openai, getUser, isSignedIn } = echo;
+```
+
+## Echo API Route
+
+```ts
+// src/app/api/echo/[...echo]/route.ts
+import { handlers } from '@/echo';
+export const { GET, POST } = handlers;
+```
+
+## Auth-Protected Chat Route
+
+Always verify the user session before forwarding requests to AI models:
+
+```ts
+// src/app/api/chat/route.ts
+import { auth } from '@/auth';
+import { openai } from '@/echo';
+import { streamText } from 'ai';
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  const { messages } = await req.json();
+  const result = streamText({ model: openai('gpt-4o'), messages });
+  return result.toDataStreamResponse();
+}
+```
+
+## Auth Route
+
+```ts
+// src/app/api/auth/[...nextauth]/route.ts
+import { handlers } from '@/auth';
+export const { GET, POST } = handlers;
+```
+
+## Key Rules
+
+- Always check `session?.user` before making AI calls — never allow unauthenticated usage.
+- Use `getUser()` from `@/echo` for Echo-native identity; use `auth()` for Next-Auth sessions.
+- Store secrets (`NEXTAUTH_SECRET`, `NEXT_PUBLIC_ECHO_APP_ID`) in `.env.local`, never in source.
+
+## Environment Variables
+
+```
+NEXT_PUBLIC_ECHO_APP_ID=your-echo-app-id
+NEXTAUTH_SECRET=your-nextauth-secret
+AUTH_GITHUB_ID=your-github-oauth-id
+AUTH_GITHUB_SECRET=your-github-oauth-secret
+```

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,62 @@
+---
+description: Guidelines for the Echo CLI template — Node.js CLI scripting with Commander.js, Echo authentication, and AI-powered chat sessions.
+globs: **/*.ts
+---
+
+# Echo CLI Guidelines
+
+This is a Node.js CLI application (`echodex`) built with Commander.js and the Echo SDK. There are no HTTP API routes — all Echo interactions happen in Node.js scripts.
+
+## CLI Entry Point (`src/index.ts`)
+
+```ts
+#!/usr/bin/env node
+import { Command } from 'commander';
+const program = new Command();
+program.name('echodex').description('CLI tool powered by Echo').version('1.0.0');
+program.command('chat').description('Start a chat session').action(startChatSession);
+program.parse(process.argv);
+```
+
+## Echo Authentication
+
+Use the auth helpers from `@/auth`, not raw SDK calls:
+
+```ts
+import { loginWithEcho, logout, isAuthenticated } from '@/auth';
+// Check auth before any AI operation:
+if (!await isAuthenticated()) await loginWithEcho();
+```
+
+## AI Streaming in CLI
+
+Use `streamText` from the `ai` package and pipe output to stdout:
+
+```ts
+import { openai } from '@/echo';
+import { streamText } from 'ai';
+
+async function chat(prompt: string) {
+  const { textStream } = streamText({ model: openai('gpt-4o'), prompt });
+  for await (const chunk of textStream) process.stdout.write(chunk);
+  console.log();
+}
+```
+
+## Config & Environment
+
+- Config lives in `src/config/` — never hardcode API keys in scripts.
+- Use `.env.local` at the project root; load with `dotenv` in `src/index.ts`.
+- The `VITE_ECHO_APP_ID` / `ECHO_APP_ID` env var must be set before running.
+
+## Key Rules
+
+- Always handle `isCancel()` from `@clack/prompts` to gracefully exit on Ctrl+C.
+- Use the `print.ts` helpers (`info`, `warning`, `header`) for consistent CLI output styling.
+- Wallet operations (`fundWallet`, `exportPrivateKey`) must confirm with the user before executing.
+
+## Environment Variables
+
+```
+ECHO_APP_ID=your-echo-app-id
+```

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,14 +1,68 @@
 ---
-description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
-globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+description: Guidelines for the Echo next-chat template — streaming chat routes, message history, and real-time UI with the AI SDK useChat hook.
+globs: **/*.ts,**/*.tsx
 ---
 
-# Echo API Route Guidelines
+# Echo Next-Chat Guidelines
 
-This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+This template is a Next.js chat application using Echo for AI-powered streaming responses.
 
-## Defining Echo Handlers
+## Echo API Route
 
-Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+```ts
+// src/app/api/echo/[...echo]/route.ts
+import { handlers } from '@/echo';
+export const { GET, POST } = handlers;
+```
 
-Example `route.ts` for an echo endpoint:
+## Streaming Chat Route
+
+```ts
+// src/app/api/chat/route.ts
+import { openai } from '@/echo';
+import { streamText } from 'ai';
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const result = streamText({
+    model: openai('gpt-4o'),
+    system: 'You are a helpful assistant.',
+    messages,
+  });
+  return result.toDataStreamResponse();
+}
+```
+
+## Frontend Hook
+
+Use the AI SDK `useChat` hook to connect to `/api/chat`:
+
+```tsx
+'use client';
+import { useChat } from 'ai/react';
+
+export function Chat() {
+  const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat();
+  return (
+    <form onSubmit={handleSubmit}>
+      {messages.map(m => (
+        <div key={m.id}><strong>{m.role}:</strong> {m.content}</div>
+      ))}
+      <input value={input} onChange={handleInputChange} disabled={isLoading} />
+      <button type="submit" disabled={isLoading}>Send</button>
+    </form>
+  );
+}
+```
+
+## Key Rules
+
+- Always stream responses — use `streamText` + `toDataStreamResponse()`, never `generateText`.
+- Pass the full `messages` array (not just the latest message) to maintain conversation context.
+- Use `system` prompt in `streamText` for persistent assistant personality/instructions.
+
+## Environment Variables
+
+```
+NEXT_PUBLIC_ECHO_APP_ID=your-echo-app-id
+```

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
+globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+---
+
+# Echo API Route Guidelines
+
+This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+
+## Defining Echo Handlers
+
+Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+
+Example `route.ts` for an echo endpoint:

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,60 @@
+---
+description: Guidelines for the Echo next-image template — AI-powered image generation routes, streaming responses, and Next.js image display.
+globs: **/*.ts,**/*.tsx
+---
+
+# Echo Next-Image Guidelines
+
+This template adds AI image generation to a Next.js app using Echo.
+
+## Echo API Route
+
+```ts
+// src/app/api/echo/[...echo]/route.ts
+import { handlers } from '@/echo';
+export const { GET, POST } = handlers;
+```
+
+## Image Generation Route
+
+```ts
+// src/app/api/generate-image/route.ts
+import { openai } from '@/echo';
+import { experimental_generateImage as generateImage } from 'ai';
+
+export async function POST(req: Request) {
+  const { prompt } = await req.json();
+  const { image } = await generateImage({
+    model: openai.image('dall-e-3'),
+    prompt,
+    size: '1024x1024',
+  });
+  return Response.json({ url: image.url });
+}
+```
+
+## Displaying Generated Images
+
+```tsx
+// src/components/GeneratedImage.tsx
+import Image from 'next/image';
+
+export function GeneratedImage({ url }: { url: string }) {
+  return (
+    <Image src={url} alt="AI generated" width={1024} height={1024}
+      style={{ maxWidth: '100%', height: 'auto' }} />
+  );
+}
+```
+
+## Key Rules
+
+- Always use `next/image` (not plain `<img>`) for generated image display — it handles CDN caching and optimisation.
+- Add the image provider domain to `next.config.ts` under `images.remotePatterns`.
+- Validate and sanitise the `prompt` parameter before passing to the model.
+
+## Environment Variables
+
+```
+NEXT_PUBLIC_ECHO_APP_ID=your-echo-app-id
+```

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,76 @@
+---
+description: Guidelines for the Echo next-video-template — AI-powered video analysis, caption generation, and Next.js video handling routes.
+globs: **/*.ts,**/*.tsx
+---
+
+# Echo Next-Video-Template Guidelines
+
+This template supports AI video processing (analysis, captions, summaries) using Echo in a Next.js app.
+
+## Echo API Route
+
+```ts
+// src/app/api/echo/[...echo]/route.ts
+import { handlers } from '@/echo';
+export const { GET, POST } = handlers;
+```
+
+## Video Analysis Route
+
+Use multimodal models to process video content:
+
+```ts
+// src/app/api/analyze-video/route.ts
+import { google } from '@/echo';
+import { generateText } from 'ai';
+
+export async function POST(req: Request) {
+  const { videoUrl, prompt } = await req.json();
+  const { text } = await generateText({
+    model: google('gemini-2.0-flash'),
+    messages: [{
+      role: 'user',
+      content: [
+        { type: 'text', text: prompt ?? 'Describe what happens in this video.' },
+        { type: 'file', data: videoUrl, mimeType: 'video/mp4' },
+      ],
+    }],
+  });
+  return Response.json({ analysis: text });
+}
+```
+
+## Streaming Caption Generation
+
+```ts
+// src/app/api/captions/route.ts
+import { google } from '@/echo';
+import { streamText } from 'ai';
+
+export async function POST(req: Request) {
+  const { videoUrl } = await req.json();
+  const result = streamText({
+    model: google('gemini-2.0-flash'),
+    messages: [{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Generate timestamped captions for this video.' },
+        { type: 'file', data: videoUrl, mimeType: 'video/mp4' },
+      ],
+    }],
+  });
+  return result.toDataStreamResponse();
+}
+```
+
+## Key Rules
+
+- Use `google('gemini-2.0-flash')` for multimodal video tasks — it has the best video understanding.
+- Always validate video URL format and file size before passing to the model.
+- For large videos, prefer streaming (`streamText`) over `generateText` to avoid timeouts.
+
+## Environment Variables
+
+```
+NEXT_PUBLIC_ECHO_APP_ID=your-echo-app-id
+```

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,14 +1,60 @@
 ---
-description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
-globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+description: Guidelines for the base Echo Next.js template — minimal echo route setup, API patterns, and environment configuration.
+globs: **/*.ts,**/*.tsx
 ---
 
-# Echo API Route Guidelines
+# Echo Next.js Guidelines
 
-This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+This is the minimal Next.js Echo template. It mounts the Echo catch-all handler and is the starting point for building AI-powered Next.js apps.
 
-## Defining Echo Handlers
+## Echo API Route
 
-Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+```ts
+// src/app/api/echo/[...echo]/route.ts
+import { handlers } from '@/echo';
+export const { GET, POST } = handlers;
+```
 
-Example `route.ts` for an echo endpoint:
+This single file is all that's needed to expose the full Echo API surface.
+
+## Adding Your First AI Route
+
+```ts
+// src/app/api/generate/route.ts
+import { openai } from '@/echo';
+import { generateText } from 'ai';
+
+export async function POST(req: Request) {
+  const { prompt } = await req.json();
+  const { text } = await generateText({
+    model: openai('gpt-4o-mini'),
+    prompt,
+  });
+  return Response.json({ text });
+}
+```
+
+For streaming, swap `generateText` for `streamText` and return `result.toDataStreamResponse()`.
+
+## Echo Path Alias
+
+The `@/echo` alias resolves to `src/lib/echo.ts` (or `echo.ts` at the root). Define it once:
+
+```ts
+import Echo from '@merit-systems/echo-next-sdk';
+const echo = Echo({ appId: process.env.NEXT_PUBLIC_ECHO_APP_ID! });
+export const { openai, anthropic, google, getUser, isSignedIn } = echo;
+export const { handlers } = echo;
+```
+
+## Key Rules
+
+- The `[...echo]` catch-all route must exist for the Echo SDK to function.
+- Do not create per-method route files (`GET.ts`, `POST.ts`) — export from one `route.ts`.
+- Use `NEXT_PUBLIC_ECHO_APP_ID` only for the app ID; keep API keys server-side.
+
+## Environment Variables
+
+```
+NEXT_PUBLIC_ECHO_APP_ID=your-echo-app-id
+```

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
+globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+---
+
+# Echo API Route Guidelines
+
+This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+
+## Defining Echo Handlers
+
+Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+
+Example `route.ts` for an echo endpoint:

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,14 +1,75 @@
 ---
-description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
-globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+description: Guidelines for the Echo API-key template — API key authentication, per-key user lookup, and protected AI routes.
+globs: **/*.ts,**/*.tsx
 ---
 
-# Echo API Route Guidelines
+# Echo Nextjs API-Key Template Guidelines
 
-This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+This template uses API keys (instead of session cookies) to authenticate requests to Echo-powered AI routes.
 
-## Defining Echo Handlers
+## Echo API Route
 
-Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+```ts
+// src/app/api/echo/[...echo]/route.ts
+import { handlers } from '@/echo';
+export const { GET, POST } = handlers;
+```
 
-Example `route.ts` for an echo endpoint:
+## API Key Validation Middleware
+
+Validate the `Authorization: Bearer <key>` header before processing AI requests:
+
+```ts
+// src/lib/auth.ts
+export async function validateApiKey(req: Request): Promise<{ userId: string } | null> {
+  const auth = req.headers.get('authorization');
+  if (!auth?.startsWith('Bearer ')) return null;
+  const key = auth.slice(7);
+  // Look up key in your database / Echo user store
+  const user = await getUserByApiKey(key);
+  return user ?? null;
+}
+```
+
+## Protected Chat Route
+
+```ts
+// src/app/api/chat/route.ts
+import { openai } from '@/echo';
+import { streamText } from 'ai';
+import { validateApiKey } from '@/lib/auth';
+
+export async function POST(req: Request) {
+  const user = await validateApiKey(req);
+  if (!user) return new Response('Unauthorized', { status: 401 });
+
+  const { messages } = await req.json();
+  const result = streamText({ model: openai('gpt-4o'), messages });
+  return result.toDataStreamResponse();
+}
+```
+
+## User Route
+
+```ts
+// src/app/api/user/route.ts
+import { getUser } from '@/echo';
+
+export async function GET(req: Request) {
+  const user = await getUser(req);
+  if (!user) return new Response('Unauthorized', { status: 401 });
+  return Response.json({ id: user.id, email: user.email });
+}
+```
+
+## Key Rules
+
+- Never log or expose API keys in responses or error messages.
+- Always return `401` (not `403`) for missing or invalid keys to avoid leaking existence info.
+- Use `getUser()` from `@/echo` as the primary identity source for Echo-authenticated requests.
+
+## Environment Variables
+
+```
+NEXT_PUBLIC_ECHO_APP_ID=your-echo-app-id
+```

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,14 @@
+---
+description: Guidelines and best practices for building API routes using the echo service, including defining handlers, request/response patterns, and error handling.
+globs: templates/**/app/api/echo/**/*.ts,templates/**/app/api/echo/**/*.tsx
+---
+
+# Echo API Route Guidelines
+
+This document provides guidelines for working with `echo` API routes within this project. The `echo` service is typically used to expose a set of API endpoints.
+
+## Defining Echo Handlers
+
+Echo API routes are generally defined by importing `handlers` from `@/echo` and exporting `GET`, `POST`, `PUT`, `DELETE`, etc., from `route.ts` files in Next.js API route directories.
+
+Example `route.ts` for an echo endpoint:

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,73 @@
+---
+description: Guidelines for the Echo React-Chat (Vite) template — EchoProvider, EchoChatProvider, useEchoModelProviders, and streaming chat in a React SPA.
+globs: **/*.ts,**/*.tsx
+---
+
+# Echo React-Chat Guidelines
+
+This is a client-side React chat app using Vite and the `@merit-systems/echo-react-sdk` with streaming AI responses.
+
+## Provider Hierarchy
+
+Nest `EchoChatProvider` inside `EchoProvider`:
+
+```tsx
+// src/App.tsx
+import { EchoProvider, EchoChatProvider } from '@merit-systems/echo-react-sdk';
+
+function App() {
+  return (
+    <EchoProvider config={{ appId: import.meta.env.VITE_ECHO_APP_ID }}>
+      <EchoChatProvider>
+        <ChatWrapper />
+      </EchoChatProvider>
+    </EchoProvider>
+  );
+}
+```
+
+## Streaming Chat with Model Providers
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { streamText, convertToModelMessages } from 'ai';
+
+export function ChatWrapper() {
+  const { openai } = useEchoModelProviders();
+
+  async function send(messages: Message[]) {
+    const { textStream } = streamText({
+      model: openai('gpt-4o'),
+      messages: convertToModelMessages(messages),
+    });
+    for await (const chunk of textStream) {
+      // append chunk to UI
+    }
+  }
+}
+```
+
+## Chat Component
+
+```tsx
+// src/chat.tsx
+import { useEcho } from '@merit-systems/echo-react-sdk';
+
+export default function Chat({ onSend }: { onSend: (params: ChatSendParams) => void }) {
+  const { isSignedIn } = useEcho();
+  if (!isSignedIn) return <p>Please sign in to chat.</p>;
+  // render message list and input
+}
+```
+
+## Key Rules
+
+- Use `convertToModelMessages` to normalise messages before passing to `streamText`.
+- `useEchoModelProviders` must be called inside a component wrapped by `EchoProvider`.
+- All env vars must be prefixed `VITE_` — this is a Vite app, not Next.js.
+
+## Environment Variables
+
+```
+VITE_ECHO_APP_ID=your-echo-app-id
+```

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,65 @@
+---
+description: Guidelines for the Echo react-image (Vite) template — client-side AI image generation using the Echo React SDK.
+globs: **/*.ts,**/*.tsx
+---
+
+# Echo React-Image Guidelines
+
+This is a client-side Vite/React app for AI image generation using the Echo React SDK.
+
+## Provider Setup
+
+```tsx
+// src/main.tsx
+import { EchoProvider } from '@merit-systems/echo-react-sdk';
+
+createRoot(document.getElementById('root')!).render(
+  <EchoProvider config={{ appId: import.meta.env.VITE_ECHO_APP_ID }}>
+    <App />
+  </EchoProvider>
+);
+```
+
+## Image Generation Hook
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { experimental_generateImage as generateImage } from 'ai';
+
+export function useImageGenerator() {
+  const { openai } = useEchoModelProviders();
+
+  async function generate(prompt: string): Promise<string> {
+    const { image } = await generateImage({
+      model: openai.image('dall-e-3'),
+      prompt,
+      size: '1024x1024',
+    });
+    return image.url;
+  }
+
+  return { generate };
+}
+```
+
+## Displaying Images
+
+```tsx
+function GeneratedImage({ url }: { url: string }) {
+  return <img src={url} alt="AI generated" style={{ maxWidth: '100%' }} />;
+}
+```
+
+Note: Unlike Next.js, Vite apps use plain `<img>` (no `next/image` optimisation layer).
+
+## Key Rules
+
+- All env vars must be prefixed `VITE_` — this is a Vite app, not Next.js.
+- `useEchoModelProviders` must be called inside a component under `EchoProvider`.
+- Show a loading state while generation is in progress — `generateImage` takes 5–15 seconds.
+
+## Environment Variables
+
+```
+VITE_ECHO_APP_ID=your-echo-app-id
+```

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,63 @@
+---
+description: Guidelines for the Echo React (Vite) template — client-side Echo SDK, EchoTokens component, and React hook usage.
+globs: **/*.ts,**/*.tsx
+---
+
+# Echo React (Vite) Guidelines
+
+This is a client-side React app using Vite and the `@merit-systems/echo-react-sdk`. There is no backend — Echo is called directly from the browser.
+
+## Echo Provider Setup
+
+Wrap your app in `EchoProvider` at the root:
+
+```tsx
+// src/main.tsx
+import { EchoProvider } from '@merit-systems/echo-react-sdk';
+
+createRoot(document.getElementById('root')!).render(
+  <EchoProvider config={{ appId: import.meta.env.VITE_ECHO_APP_ID }}>
+    <App />
+  </EchoProvider>
+);
+```
+
+## Using Echo Tokens
+
+```tsx
+// src/App.tsx
+import { EchoTokens } from '@merit-systems/echo-react-sdk';
+
+function App() {
+  return (
+    <>
+      <h1>Welcome to Echo</h1>
+      <EchoTokens />
+    </>
+  );
+}
+```
+
+## Accessing Echo State
+
+```tsx
+import { useEcho } from '@merit-systems/echo-react-sdk';
+
+function Profile() {
+  const { user, isSignedIn } = useEcho();
+  if (!isSignedIn) return <button>Sign In</button>;
+  return <p>Hello, {user?.email}</p>;
+}
+```
+
+## Key Rules
+
+- Always use `import.meta.env.VITE_ECHO_APP_ID` (not `process.env`) — this is a Vite app.
+- All env vars exposed to the browser must be prefixed with `VITE_`.
+- `EchoProvider` must be an ancestor of any component using `useEcho` or `EchoTokens`.
+
+## Environment Variables
+
+```
+VITE_ECHO_APP_ID=your-echo-app-id
+```


### PR DESCRIPTION
Closes #636

## What changed

Added a tailored `.cursor/rules/echo_rules.mdc` to all 11 echo-start templates. Each file is specific to that template's use case — which is what #636 asked for.

| Template | Rules focus |
|----------|-------------|
| `assistant-ui` | Multi-provider AI (OpenAI/Anthropic/Google), tool calling |
| `authjs` | Next-Auth session validation, auth-protected routes |
| `next-chat` | Streaming chat, `useChat` hook, conversation history |
| `next` | Minimal catch-all route setup, basic AI route |
| `nextjs-api-key-template` | API key auth, Bearer header validation |
| `echo-cli` | Commander.js CLI, Node.js streaming, `clack/prompts` |
| `react` | Vite + `EchoProvider`, `EchoTokens` |
| `react-chat` | `EchoChatProvider`, `useEchoModelProviders`, streaming |
| `next-image` | DALL-E image generation, `next/image` display |
| `next-video-template` | Gemini multimodal video analysis |
| `react-image` | Vite image generation hook |

Also fixed `globs` front-matter — the original files used `templates/**/...` paths that would never match inside a template. Each file now uses `**/*.ts,**/*.tsx` relative to its own root.