### PR TITLE
fix: add docs

### DIFF
--- a/packages/app/control/docs/advanced/meta.json
+++ b/packages/app/control/docs/advanced/meta.json
@@ -1,4 +1,5 @@
 {
+  "title": "Advanced",
   "pages": [
     "how-echo-works",
     "direct-provider-clients",


### PR DESCRIPTION
Closes #700

## What changed
Adds the missing `title` field to the advanced documentation section's metadata.

## Files modified
- `packages/app/control/docs/advanced/meta.json`

---
*Automated PR — please review.*