### PR TITLE
Add .cursor/rules/echo_rules.mdc to echo-start templates

### DIFF
--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,48 @@
+---
+description: Echo SDK guidelines for CLI tools — user-pays AI infrastructure
+globs: **/*.ts,**/*.js
+---
+
+# Echo SDK Guidelines (CLI)
+
+Echo lets CLI tools authenticate users and let them pay for their own AI usage.
+
+## Authentication
+
+Use Echo's auth functions for CLI login flow:
+
+```typescript
+import { loginWithEcho, logout, isAuthenticated } from '@/auth';
+
+// Login
+await loginWithEcho();
+
+// Check auth
+if (await isAuthenticated()) {
+  // proceed
+}
+
+// Logout
+await logout();
+```
+
+## Wallet management
+
+```typescript
+import { 
+  initLocalWallet, 
+  loginWithWallet,
+  showLocalWalletBalance,
+  showLocalWalletAddress,
+  exportPrivateKey,
+  fundWallet
+} from '@/core';
+```
+
+## Key rules
+
+- Use `@merit-systems/echo-sdk` for CLI applications
+- Use `commander` for CLI argument parsing
+- Use `@clack/prompts` for interactive prompts
+- Handle `isCancel` from prompts to allow graceful exit
+- Store auth tokens securely, never log them

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,89 @@
+---
+description: Echo SDK guidelines for Next.js — user-pays AI infrastructure
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo SDK Guidelines (Next.js)
+
+Echo lets users pay for their own AI usage — you never front API costs. Replace standard AI SDK imports with Echo and earn revenue via markup.
+
+## Setup
+
+### Server-side configuration
+Create `src/echo/index.ts` and initialize Echo:
+
+```typescript
+import Echo from '@merit-systems/echo-next-sdk';
+
+export const { handlers, isSignedIn, openai, anthropic } = Echo({
+  appId: process.env.ECHO_APP_ID!,
+});
+```
+
+### Client-side provider
+Wrap your app in `EchoProvider` in your layout or providers file:
+
+```typescript
+'use client';
+import { EchoProvider } from '@merit-systems/echo-next-sdk/client';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <EchoProvider config={{ appId: process.env.NEXT_PUBLIC_ECHO_APP_ID! }}>
+      {children}
+    </EchoProvider>
+  );
+}
+```
+
+### Environment variables
+- `ECHO_APP_ID` — Server-side app ID (from echo.merit.systems)
+- `NEXT_PUBLIC_ECHO_APP_ID` — Client-side app ID (same value, must be prefixed with NEXT_PUBLIC_)
+
+## Using Echo model providers
+
+Import model providers from your Echo config instead of directly from the AI SDK:
+
+```typescript
+import { openai, anthropic } from '@/echo';
+import { generateText } from 'ai';
+
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+Do NOT hardcode API keys — Echo handles authentication and billing.
+
+## UI components
+
+### Token balance display
+Use `EchoTokens` to show user balance and login:
+
+```typescript
+'use client';
+import { EchoTokens } from '@merit-systems/echo-next-sdk/client';
+
+export function EchoButton() {
+  return <EchoTokens />;
+}
+```
+
+## API routes
+
+Register the Echo auth handler in `src/app/api/echo/[...echo]/route.ts`:
+
+```typescript
+import { handlers } from '@/echo';
+export const { GET, POST } = handlers;
+```
+
+## Key rules
+
+- ALWAYS use `@merit-systems/echo-next-sdk` for Next.js apps (not the React or plain SDK)
+- ALWAYS wrap the app in `EchoProvider` on the client side
+- ALWAYS use the server-side Echo config for AI model providers
+- NEVER hardcode API keys — Echo manages authentication
+- Use `'use client'` directive for components importing from `echo-next-sdk/client`
+- The `EchoTokens` component handles OAuth login flow and balance display

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,69 @@
+---
+description: Echo SDK guidelines for React — user-pays AI infrastructure
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo SDK Guidelines (React)
+
+Echo lets users pay for their own AI usage — you never front API costs. Replace standard AI SDK imports with Echo and earn revenue via markup.
+
+## Setup
+
+### Provider setup
+Wrap your app in `EchoProvider` in `main.tsx`:
+
+```typescript
+import { EchoProvider } from '@merit-systems/echo-react-sdk';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <EchoProvider config={{ appId: import.meta.env.VITE_ECHO_APP_ID! }}>
+      <App />
+    </EchoProvider>
+  </StrictMode>
+);
+```
+
+### Environment variables
+- `VITE_ECHO_APP_ID` — App ID from echo.merit.systems (Vite requires VITE_ prefix)
+
+## Using Echo model providers
+
+```typescript
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { generateText } from 'ai';
+
+function MyComponent() {
+  const { openai } = useEchoModelProviders();
+
+  const handleGenerate = async () => {
+    const response = await generateText({
+      model: openai('gpt-4o'),
+      prompt: '...',
+    });
+  };
+}
+```
+
+## UI components
+
+```typescript
+import { EchoTokens } from '@merit-systems/echo-react-sdk';
+
+function App() {
+  return (
+    <>
+      <h1>My App</h1>
+      <EchoTokens />
+    </>
+  );
+}
+```
+
+## Key rules
+
+- ALWAYS use `@merit-systems/echo-react-sdk` for React apps (not the Next.js SDK)
+- ALWAYS wrap the app in `EchoProvider` at the root
+- Use `useEchoModelProviders()` hook to get AI model providers
+- NEVER hardcode API keys — Echo manages authentication
+- Use `EchoTokens` component for user balance and login UI


### PR DESCRIPTION
Hey! Saw the issue about adding Cursor rules to the templates — figured I'd put together something useful.

I added `.cursor/rules/echo_rules.mdc` files to the three main template types:

- **Next.js** (`templates/next/`) — covers server/client setup, model provider usage, EchoProvider wrapping, and the API route pattern
- **React** (`templates/react/`) — covers Vite-specific setup, the `useEchoModelProviders` hook, and EchoTokens component
- **CLI** (`templates/echo-cli/`) — covers auth flow, wallet management, and prompt patterns

Each file is tailored to its framework so Cursor will give relevant suggestions based on the template you're working in. The rules follow the same format as the Convex example in the issue.

Would love feedback on the approach! Happy to adjust if you'd prefer a different structure or want to cover more of the templates.

Fixes #636