### PR TITLE
feat: add .cursor/rules/echo_rules.mdc to echo-start templates

### DIFF
--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,27 @@
+---
+description: Echo template rules for Next.js projects (App Router).
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + Next.js template rules
+
+## Project shape
+- This is a Next.js (App Router) project.
+- Prefer React Server Components where appropriate; only add `"use client"` when needed.
+
+## API routes
+- API routes live under `app/api/**/route.ts`.
+- Keep handlers small; factor reusable logic into `lib/`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- When documenting setup, update README and keep `.env.example` in sync.
+
+## TypeScript + lint
+- Keep types strict and avoid `any`.
+- Prefer `zod` or existing validators in the template when validating inputs.
+
+## Echo integration
+- When wiring Echo endpoints, keep the `/api/echo/*` surface consistent with the template.
+- Avoid breaking changes to request/response shapes.

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,27 @@
+---
+description: Echo template rules for Next.js projects (App Router).
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + Next.js template rules
+
+## Project shape
+- This is a Next.js (App Router) project.
+- Prefer React Server Components where appropriate; only add `"use client"` when needed.
+
+## API routes
+- API routes live under `app/api/**/route.ts`.
+- Keep handlers small; factor reusable logic into `lib/`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- When documenting setup, update README and keep `.env.example` in sync.
+
+## TypeScript + lint
+- Keep types strict and avoid `any`.
+- Prefer `zod` or existing validators in the template when validating inputs.
+
+## Echo integration
+- When wiring Echo endpoints, keep the `/api/echo/*` surface consistent with the template.
+- Avoid breaking changes to request/response shapes.

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,19 @@
+---
+description: Echo template rules for Node.js CLI projects.
+globs: "**/*.{ts,js,md,json}"
+alwaysApply: true
+---
+
+# Echo CLI template rules
+
+## Runtime
+- This is a Node.js CLI.
+- Prefer small pure functions and keep side-effects near the entrypoint.
+
+## Config + secrets
+- Never invent API keys. Read configuration from `.env.local` or other documented config files.
+- Do not log secrets.
+
+## UX
+- CLI output should be concise and actionable.
+- Always return non-zero exit codes on failure.

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,27 @@
+---
+description: Echo template rules for Next.js projects (App Router).
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + Next.js template rules
+
+## Project shape
+- This is a Next.js (App Router) project.
+- Prefer React Server Components where appropriate; only add `"use client"` when needed.
+
+## API routes
+- API routes live under `app/api/**/route.ts`.
+- Keep handlers small; factor reusable logic into `lib/`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- When documenting setup, update README and keep `.env.example` in sync.
+
+## TypeScript + lint
+- Keep types strict and avoid `any`.
+- Prefer `zod` or existing validators in the template when validating inputs.
+
+## Echo integration
+- When wiring Echo endpoints, keep the `/api/echo/*` surface consistent with the template.
+- Avoid breaking changes to request/response shapes.

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,27 @@
+---
+description: Echo template rules for Next.js projects (App Router).
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + Next.js template rules
+
+## Project shape
+- This is a Next.js (App Router) project.
+- Prefer React Server Components where appropriate; only add `"use client"` when needed.
+
+## API routes
+- API routes live under `app/api/**/route.ts`.
+- Keep handlers small; factor reusable logic into `lib/`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- When documenting setup, update README and keep `.env.example` in sync.
+
+## TypeScript + lint
+- Keep types strict and avoid `any`.
+- Prefer `zod` or existing validators in the template when validating inputs.
+
+## Echo integration
+- When wiring Echo endpoints, keep the `/api/echo/*` surface consistent with the template.
+- Avoid breaking changes to request/response shapes.

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,27 @@
+---
+description: Echo template rules for Next.js projects (App Router).
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + Next.js template rules
+
+## Project shape
+- This is a Next.js (App Router) project.
+- Prefer React Server Components where appropriate; only add `"use client"` when needed.
+
+## API routes
+- API routes live under `app/api/**/route.ts`.
+- Keep handlers small; factor reusable logic into `lib/`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- When documenting setup, update README and keep `.env.example` in sync.
+
+## TypeScript + lint
+- Keep types strict and avoid `any`.
+- Prefer `zod` or existing validators in the template when validating inputs.
+
+## Echo integration
+- When wiring Echo endpoints, keep the `/api/echo/*` surface consistent with the template.
+- Avoid breaking changes to request/response shapes.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,27 @@
+---
+description: Echo template rules for Next.js projects (App Router).
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + Next.js template rules
+
+## Project shape
+- This is a Next.js (App Router) project.
+- Prefer React Server Components where appropriate; only add `"use client"` when needed.
+
+## API routes
+- API routes live under `app/api/**/route.ts`.
+- Keep handlers small; factor reusable logic into `lib/`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- When documenting setup, update README and keep `.env.example` in sync.
+
+## TypeScript + lint
+- Keep types strict and avoid `any`.
+- Prefer `zod` or existing validators in the template when validating inputs.
+
+## Echo integration
+- When wiring Echo endpoints, keep the `/api/echo/*` surface consistent with the template.
+- Avoid breaking changes to request/response shapes.

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,27 @@
+---
+description: Echo template rules for Next.js projects (App Router).
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + Next.js template rules
+
+## Project shape
+- This is a Next.js (App Router) project.
+- Prefer React Server Components where appropriate; only add `"use client"` when needed.
+
+## API routes
+- API routes live under `app/api/**/route.ts`.
+- Keep handlers small; factor reusable logic into `lib/`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- When documenting setup, update README and keep `.env.example` in sync.
+
+## TypeScript + lint
+- Keep types strict and avoid `any`.
+- Prefer `zod` or existing validators in the template when validating inputs.
+
+## Echo integration
+- When wiring Echo endpoints, keep the `/api/echo/*` surface consistent with the template.
+- Avoid breaking changes to request/response shapes.

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,22 @@
+---
+description: Echo template rules for React (Vite) projects.
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + React template rules
+
+## Project shape
+- This is a React + Vite project.
+- Prefer colocating UI components under `src/components`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- Keep `.env.example` up to date.
+
+## TypeScript
+- Avoid `any`; prefer explicit types.
+
+## Echo integration
+- If adding API calls, keep them in a small client module (e.g. `src/lib/echo.ts`).
+- Handle network errors and show useful UI fallbacks.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,22 @@
+---
+description: Echo template rules for React (Vite) projects.
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + React template rules
+
+## Project shape
+- This is a React + Vite project.
+- Prefer colocating UI components under `src/components`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- Keep `.env.example` up to date.
+
+## TypeScript
+- Avoid `any`; prefer explicit types.
+
+## Echo integration
+- If adding API calls, keep them in a small client module (e.g. `src/lib/echo.ts`).
+- Handle network errors and show useful UI fallbacks.

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,22 @@
+---
+description: Echo template rules for React (Vite) projects.
+globs: "**/*.{ts,tsx,js,jsx,md,mdx,json}"
+alwaysApply: true
+---
+
+# Echo + React template rules
+
+## Project shape
+- This is a React + Vite project.
+- Prefer colocating UI components under `src/components`.
+
+## Env configuration
+- Never invent API keys. Use values from `.env.local` / `.env.example`.
+- Keep `.env.example` up to date.
+
+## TypeScript
+- Avoid `any`; prefer explicit types.
+
+## Echo integration
+- If adding API calls, keep them in a small client module (e.g. `src/lib/echo.ts`).
+- Handle network errors and show useful UI fallbacks.


### PR DESCRIPTION
## Summary
Adds tailored Cursor rules (`.cursor/rules/echo_rules.mdc`) to every echo-start template.

Each template type gets rules specific to its framework:

| Template | Rules type |
|---|---|
| next, next-chat, next-image, next-video-template, assistant-ui, authjs, nextjs-api-key-template | Next.js (App Router) |
| react, react-chat, react-image | React (Vite) |
| echo-cli | Node.js CLI |

The rules cover project shape, env/config, TypeScript, and Echo integration patterns — matching the style of the existing `packages/app/control/.cursor/rules/posthog-integration.mdc`.

Closes #636