### PR TITLE
feat: add Veo 3.1 video model support

### DIFF
--- a/packages/sdk/ts/src/__tests__/video-models.test.ts
+++ b/packages/sdk/ts/src/__tests__/video-models.test.ts
@@ -1,0 +1,34 @@
+import { VertexAIVideoModels } from '../supported-models/video/vertex-ai';
+
+describe('Vertex AI video models', () => {
+  it('includes Veo 3.1 model variants', () => {
+    const modelIds = VertexAIVideoModels.map(model => model.model_id);
+
+    expect(modelIds).toContain('veo-3.1-fast-generate-001');
+    expect(modelIds).toContain('veo-3.1-generate-001');
+    expect(modelIds).toContain('veo-3.1-fast-generate-preview');
+    expect(modelIds).toContain('veo-3.1-generate-preview');
+  });
+
+  it('uses current Veo 3.1 Vertex AI pricing', () => {
+    expect(
+      VertexAIVideoModels.find(
+        model => model.model_id === 'veo-3.1-fast-generate-001'
+      )
+    ).toMatchObject({
+      cost_per_second_with_audio: 0.12,
+      cost_per_second_without_audio: 0.1,
+      provider: 'VertexAI',
+    });
+
+    expect(
+      VertexAIVideoModels.find(
+        model => model.model_id === 'veo-3.1-generate-001'
+      )
+    ).toMatchObject({
+      cost_per_second_with_audio: 0.4,
+      cost_per_second_without_audio: 0.2,
+      provider: 'VertexAI',
+    });
+  });
+});

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -1,16 +1,46 @@
 import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
+  | 'veo-3.1-fast-generate-001'
+  | 'veo-3.1-generate-001'
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 /**
  * Vertex AI video models with official pricing information
  * Based on: https://cloud.google.com/vertex-ai/generative-ai/pricing
  *
+ * Veo 3.1: $0.40/second with audio, $0.20/second video only
+ * Veo 3.1 Fast: $0.10-$0.12/second with audio, $0.08-$0.10/second video only
  * Veo 3: $0.40/second with audio, $0.20/second video only
  * Veo 3 Fast: $0.15/second with audio, $0.10/second video only
  */
 export const VertexAIVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-fast-generate-001',
+    cost_per_second_with_audio: 0.12,
+    cost_per_second_without_audio: 0.1,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-001',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.12,
+    cost_per_second_without_audio: 0.1,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
   {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,6 +35,10 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
+    'veo-3.1-fast-generate-001',
+    'veo-3.1-generate-001',
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
   ];

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -4,6 +4,7 @@
 
 import { getEchoToken } from '@/echo';
 import { ERROR_MESSAGES } from '@/lib/constants';
+import type { VideoModelOption } from '@/lib/types';
 import {
   GenerateVideosOperation,
   GenerateVideosParameters,
@@ -14,7 +15,7 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model: VideoModelOption,
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,6 +42,8 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
+  { id: 'veo-3.1-fast-generate-001', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-001', name: 'Veo 3.1' },
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
 ];
@@ -57,7 +59,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-001'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,6 +14,10 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
+  | 'veo-3.1-fast-generate-001'
+  | 'veo-3.1-generate-001'
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 


### PR DESCRIPTION
## Summary
- add Veo 3.1 Vertex AI video model IDs to the TypeScript SDK model list
- update the Next video template model types, validation, API handler, and selector
- default the video template to `veo-3.1-fast-generate-001`
- keep the preview model IDs requested in the issue alongside the current GA model IDs
- add SDK coverage for the new Veo 3.1 model entries

Closes #595.

## Notes
Google's current Vertex AI docs list GA Veo 3.1 IDs and mark the preview IDs for migration. This keeps the preview IDs requested in the issue while using the GA fast model as the template default.

## Verification
- `git diff --check`
- attempted local SDK test install/run; the local JS runner hung before producing test output in this workspace, so the included regression test has not been executed here
