### PR TITLE
feat: add Echo Cursor rules to templates

### DIFF
--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,46 @@
+---
+description: Echo guidelines for this template: Assistant UI chat template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## Next.js rules
+
+- Keep server-only Echo initialization in server files such as `src/echo`, API routes, or server actions.
+- Put client-only Echo UI/provider components behind `'use client'`.
+- Never import server-only Echo helpers into client components. Use API routes for browser initiated generation/payment work.
+- Register Echo route handlers at the path expected by the template and keep route exports explicit (`GET`, `POST`).
+- Use `process.env.ECHO_APP_ID` for server-side configuration and `NEXT_PUBLIC_ECHO_APP_ID` only for public client config.
+- For streaming responses, return the AI SDK response helper directly and set route runtime/max duration intentionally.
+
+## Chat template rules
+
+- Keep message objects typed with explicit `role` and `content` fields.
+- Validate incoming `messages` arrays before streaming/generating responses.
+- Centralize selectable model IDs and provider labels.
+- Preserve streaming behavior and avoid buffering full responses unless the template already does so.
+
+## Assistant UI rules
+
+- Keep assistant state, transport configuration, and Echo/provider calls separated from presentational components.
+- Preserve streaming UX, cancellation, loading states, and error messages.
+- Keep tool/model configuration typed and centralized.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,39 @@
+---
+description: Echo guidelines for this template: Auth.js authentication template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## Next.js rules
+
+- Keep server-only Echo initialization in server files such as `src/echo`, API routes, or server actions.
+- Put client-only Echo UI/provider components behind `'use client'`.
+- Never import server-only Echo helpers into client components. Use API routes for browser initiated generation/payment work.
+- Register Echo route handlers at the path expected by the template and keep route exports explicit (`GET`, `POST`).
+- Use `process.env.ECHO_APP_ID` for server-side configuration and `NEXT_PUBLIC_ECHO_APP_ID` only for public client config.
+- For streaming responses, return the AI SDK response helper directly and set route runtime/max duration intentionally.
+
+## Auth rules
+
+- Keep Auth.js and Echo auth responsibilities separate and clearly typed.
+- Do not leak session tokens, provider secrets, or Echo app secrets to client components.
+- Validate callbacks/session shapes and prefer existing helper functions over duplicate auth code.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,31 @@
+---
+description: Echo guidelines for this template: Echo CLI template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## CLI rules
+
+- Read Echo configuration from environment variables or explicit CLI flags. Never commit local secrets or generated credentials.
+- Validate required flags/environment at command startup and exit with actionable messages.
+- Keep commands composable: return non-zero on failure, print machine-readable output where useful, and avoid interactive prompts in scripted paths.
+- Use the existing package manager/script conventions for build, lint, and start commands.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,40 @@
+---
+description: Echo guidelines for this template: Next.js chat template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## Next.js rules
+
+- Keep server-only Echo initialization in server files such as `src/echo`, API routes, or server actions.
+- Put client-only Echo UI/provider components behind `'use client'`.
+- Never import server-only Echo helpers into client components. Use API routes for browser initiated generation/payment work.
+- Register Echo route handlers at the path expected by the template and keep route exports explicit (`GET`, `POST`).
+- Use `process.env.ECHO_APP_ID` for server-side configuration and `NEXT_PUBLIC_ECHO_APP_ID` only for public client config.
+- For streaming responses, return the AI SDK response helper directly and set route runtime/max duration intentionally.
+
+## Chat template rules
+
+- Keep message objects typed with explicit `role` and `content` fields.
+- Validate incoming `messages` arrays before streaming/generating responses.
+- Centralize selectable model IDs and provider labels.
+- Preserve streaming behavior and avoid buffering full responses unless the template already does so.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,39 @@
+---
+description: Echo guidelines for this template: Next.js image generation/editing template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## Next.js rules
+
+- Keep server-only Echo initialization in server files such as `src/echo`, API routes, or server actions.
+- Put client-only Echo UI/provider components behind `'use client'`.
+- Never import server-only Echo helpers into client components. Use API routes for browser initiated generation/payment work.
+- Register Echo route handlers at the path expected by the template and keep route exports explicit (`GET`, `POST`).
+- Use `process.env.ECHO_APP_ID` for server-side configuration and `NEXT_PUBLIC_ECHO_APP_ID` only for public client config.
+- For streaming responses, return the AI SDK response helper directly and set route runtime/max duration intentionally.
+
+## Image template rules
+
+- Keep image generation/edit routes server-side. Do not expose provider credentials in client components.
+- Validate prompt/image inputs, content types, and empty responses before returning image data.
+- Prefer currently supported model IDs and keep them in one typed list when exposed to users.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,39 @@
+---
+description: Echo guidelines for this template: Next.js video generation template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## Next.js rules
+
+- Keep server-only Echo initialization in server files such as `src/echo`, API routes, or server actions.
+- Put client-only Echo UI/provider components behind `'use client'`.
+- Never import server-only Echo helpers into client components. Use API routes for browser initiated generation/payment work.
+- Register Echo route handlers at the path expected by the template and keep route exports explicit (`GET`, `POST`).
+- Use `process.env.ECHO_APP_ID` for server-side configuration and `NEXT_PUBLIC_ECHO_APP_ID` only for public client config.
+- For streaming responses, return the AI SDK response helper directly and set route runtime/max duration intentionally.
+
+## Video template rules
+
+- Treat video generation as an async operation: preserve polling/status handling and clear user-facing progress states.
+- Validate prompts, aspect ratio/duration/model choices, and provider operation IDs.
+- Keep provider-specific operation parsing in utility functions with tests when practical.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,33 @@
+---
+description: Echo guidelines for this template: Next.js app template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## Next.js rules
+
+- Keep server-only Echo initialization in server files such as `src/echo`, API routes, or server actions.
+- Put client-only Echo UI/provider components behind `'use client'`.
+- Never import server-only Echo helpers into client components. Use API routes for browser initiated generation/payment work.
+- Register Echo route handlers at the path expected by the template and keep route exports explicit (`GET`, `POST`).
+- Use `process.env.ECHO_APP_ID` for server-side configuration and `NEXT_PUBLIC_ECHO_APP_ID` only for public client config.
+- For streaming responses, return the AI SDK response helper directly and set route runtime/max duration intentionally.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,33 @@
+---
+description: Echo guidelines for this template: Next.js API-key authentication template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## Next.js rules
+
+- Keep server-only Echo initialization in server files such as `src/echo`, API routes, or server actions.
+- Put client-only Echo UI/provider components behind `'use client'`.
+- Never import server-only Echo helpers into client components. Use API routes for browser initiated generation/payment work.
+- Register Echo route handlers at the path expected by the template and keep route exports explicit (`GET`, `POST`).
+- Use `process.env.ECHO_APP_ID` for server-side configuration and `NEXT_PUBLIC_ECHO_APP_ID` only for public client config.
+- For streaming responses, return the AI SDK response helper directly and set route runtime/max duration intentionally.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,38 @@
+---
+description: Echo guidelines for this template: React chat template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## React/Vite rules
+
+- Keep public Echo config in `VITE_` environment variables only. Never expose server-only secrets to the browser.
+- Route paid/model work through the configured Echo client or backend API; do not add raw provider API keys to React components.
+- Keep reusable Echo UI in components and shared request/model types in `src/lib` or an equivalent template-local folder.
+- Handle loading, success, empty, and error states explicitly for Echo-powered actions.
+
+## Chat template rules
+
+- Keep message objects typed with explicit `role` and `content` fields.
+- Validate incoming `messages` arrays before streaming/generating responses.
+- Centralize selectable model IDs and provider labels.
+- Preserve streaming behavior and avoid buffering full responses unless the template already does so.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,37 @@
+---
+description: Echo guidelines for this template: React image generation/editing template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## React/Vite rules
+
+- Keep public Echo config in `VITE_` environment variables only. Never expose server-only secrets to the browser.
+- Route paid/model work through the configured Echo client or backend API; do not add raw provider API keys to React components.
+- Keep reusable Echo UI in components and shared request/model types in `src/lib` or an equivalent template-local folder.
+- Handle loading, success, empty, and error states explicitly for Echo-powered actions.
+
+## Image template rules
+
+- Keep image generation/edit routes server-side. Do not expose provider credentials in client components.
+- Validate prompt/image inputs, content types, and empty responses before returning image data.
+- Prefer currently supported model IDs and keep them in one typed list when exposed to users.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,31 @@
+---
+description: Echo guidelines for this template: React/Vite app template. Covers Echo SDK usage, framework boundaries, environment variables, model calls, payments/auth, and project conventions.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template rules
+
+These rules apply when editing this Echo starter template. Prefer small, typed changes that preserve the existing template shape and developer experience.
+
+## Universal Echo rules
+
+- Keep Echo app IDs, API keys, wallet secrets, provider keys, and tokens in environment variables. Never hardcode secrets.
+- Use the Echo SDK helpers already present in the template instead of creating parallel clients or raw fetch wrappers.
+- Validate request bodies before calling model providers or payment/auth helpers. Return clear HTTP errors for bad input.
+- Keep provider/model names in one typed place when a template exposes model selection.
+- Do not call paid/model APIs from unit tests. Mock SDK/provider calls.
+- Preserve TypeScript strictness: avoid `any`, export shared types, and keep runtime validation aligned with TypeScript types.
+- Keep example code copy-pasteable for new Echo users.
+
+## React/Vite rules
+
+- Keep public Echo config in `VITE_` environment variables only. Never expose server-only secrets to the browser.
+- Route paid/model work through the configured Echo client or backend API; do not add raw provider API keys to React components.
+- Keep reusable Echo UI in components and shared request/model types in `src/lib` or an equivalent template-local folder.
+- Handle loading, success, empty, and error states explicitly for Echo-powered actions.
+
+## Editing checklist
+
+- Keep changes minimal and framework-specific.
+- Run the narrowest relevant build/type-check before submitting.
+- Update this rule file when template conventions change.


### PR DESCRIPTION
## Summary
- Adds `.cursor/rules/echo_rules.mdc` to all 11 Echo templates
- Tailors guidance for Next.js, React/Vite, CLI, chat, image, video, Auth.js, and assistant-ui templates
- Covers Echo SDK usage, environment variable boundaries, API route/client-server separation, validation, testing, and editing checklists

## Verification
- `git diff --check` passed
- `corepack pnpm -C packages/sdk/echo-start run build` passed

/claim #636
