### PR TITLE
feat: add Veo 3.1 video models

### DIFF
--- a/packages/app/server/src/providers/VertexAIProvider.ts
+++ b/packages/app/server/src/providers/VertexAIProvider.ts
@@ -19,6 +19,8 @@ import { env } from '../env';
 // Constants
 export const PROXY_PASSTHROUGH_ONLY_MODEL = 'PROXY_PLACEHOLDER_VERTEX_AI';
 const VEO3_MODELS = [
+  'veo-3.1-fast-generate-preview',
+  'veo-3.1-generate-preview',
   'veo-3.0-fast-generate-preview',
   'veo-3.0-generate-preview',
 ];

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -1,6 +1,8 @@
 import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 /**
@@ -11,6 +13,18 @@ export type VertexAIVideoModel =
  * Veo 3 Fast: $0.15/second with audio, $0.10/second video only
  */
 export const VertexAIVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.1,
+    cost_per_second_without_audio: 0.08,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
   {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,6 +35,8 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
   ];

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -14,7 +14,11 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model:
+    | 'veo-3.1-fast-generate-preview'
+    | 'veo-3.1-generate-preview'
+    | 'veo-3.0-fast-generate-preview'
+    | 'veo-3.0-generate-preview',
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,6 +42,8 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1' },
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
 ];
@@ -57,7 +59,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-preview'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,6 +14,8 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 


### PR DESCRIPTION
## Summary
- Adds Vertex AI support for `veo-3.1-fast-generate-preview` and `veo-3.1-generate-preview`
- Adds Veo 3.1 model pricing to the SDK video model registry
- Updates the Next video template model picker, request validation, and handler types
- Makes Veo 3.1 Fast the default template model

## Verification
- `git diff --check` passed
- `corepack pnpm -C packages/sdk/ts run build` passed

/claim #595
