### PR TITLE
fix: support veo 3.1 video models

### DIFF
--- a/packages/app/server/src/__tests__/provider-factory.test.ts
+++ b/packages/app/server/src/__tests__/provider-factory.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ProviderType } from '../providers/ProviderType';
+import { GeminiVeoProvider } from '../providers/GeminiVeoProvider';
+import { getProvider } from '../providers/ProviderFactory';
+import { VertexAIProvider } from '../providers/VertexAIProvider';
+
+vi.mock('../server', () => ({
+  prisma: {},
+}));
+
+vi.mock('../services/DbService', () => ({
+  EchoDbService: class EchoDbService {
+    confirmAccessControl(): Promise<boolean> {
+      return Promise.resolve(true);
+    }
+  },
+}));
+
+vi.mock('../providers/OpenAIVideoProvider', () => ({
+  OpenAIVideoProvider: class OpenAIVideoProvider {},
+}));
+
+describe('getProvider', () => {
+  it('routes shared Veo 3.1 preview model IDs by request path', () => {
+    expect(
+      getProvider(
+        'veo-3.1-fast-generate-preview',
+        false,
+        '/v1beta/models/veo-3.1-fast-generate-preview:predictLongRunning'
+      )
+    ).toBeInstanceOf(GeminiVeoProvider);
+
+    expect(
+      getProvider(
+        'veo-3.1-fast-generate-preview',
+        false,
+        '/v1/publishers/google/models/veo-3.1-fast-generate-preview:predictLongRunning'
+      )
+    ).toBeInstanceOf(VertexAIProvider);
+  });
+
+  it('routes Veo 3.1 GA Vertex AI model IDs to the Vertex AI provider', () => {
+    expect(
+      getProvider(
+        'veo-3.1-fast-generate-001',
+        false,
+        '/v1/publishers/google/models/veo-3.1-fast-generate-001:predictLongRunning'
+      ).getType()
+    ).toBe(ProviderType.VERTEX_AI);
+  });
+});
+
+describe('VertexAIProvider', () => {
+  it('normalizes Google SDK publisher paths when formatting upstream URLs', () => {
+    process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+
+    const provider = new VertexAIProvider(false, 'veo-3.1-fast-generate-001');
+
+    expect(
+      provider.formatUpstreamUrl({
+        path: '/v1/publishers/google/models/veo-3.1-fast-generate-001:predictLongRunning',
+        url: '/v1/publishers/google/models/veo-3.1-fast-generate-001:predictLongRunning?alt=json',
+      })
+    ).toBe(
+      'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/google/models/veo-3.1-fast-generate-001:predictLongRunning?alt=json'
+    );
+  });
+});

--- a/packages/app/server/src/__tests__/string-parsing.test.ts
+++ b/packages/app/server/src/__tests__/string-parsing.test.ts
@@ -1,0 +1,14 @@
+import type { Request } from 'express';
+import { describe, expect, it } from 'vitest';
+
+import { extractGeminiModelName } from '../utils/gemini/string-parsing';
+
+describe('extractGeminiModelName', () => {
+  it('extracts model names from full Vertex AI project paths', () => {
+    const req = {
+      path: '/v1/projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-fast-generate-001:predictLongRunning',
+    } as unknown as Request;
+
+    expect(extractGeminiModelName(req)).toBe('veo-3.1-fast-generate-001');
+  });
+});

--- a/packages/app/server/src/providers/ProviderFactory.ts
+++ b/packages/app/server/src/providers/ProviderFactory.ts
@@ -97,6 +97,49 @@ const createVideoModelToProviderMapping = (): Record<string, ProviderType> => {
   return mapping;
 };
 
+const createVideoModelProviders = (): Record<string, Set<string>> => {
+  const mapping: Record<string, Set<string>> = {};
+
+  for (const modelConfig of ALL_SUPPORTED_VIDEO_MODELS) {
+    if (!modelConfig.provider) {
+      continue;
+    }
+
+    const providers = mapping[modelConfig.model_id] ?? new Set<string>();
+    providers.add(modelConfig.provider);
+    mapping[modelConfig.model_id] = providers;
+  }
+
+  return mapping;
+};
+
+const isVertexAIVideoPath = (completionPath: string): boolean => {
+  return completionPath.includes('/publishers/google/models/');
+};
+
+const videoModelHasProvider = (model: string, provider: string): boolean => {
+  return VIDEO_MODEL_PROVIDERS[model]?.has(provider) ?? false;
+};
+
+const resolveVideoProviderType = (
+  model: string,
+  defaultType: ProviderType,
+  completionPath: string
+): ProviderType => {
+  if (
+    isVertexAIVideoPath(completionPath) &&
+    videoModelHasProvider(model, 'VertexAI')
+  ) {
+    return ProviderType.VERTEX_AI;
+  }
+
+  if (videoModelHasProvider(model, 'Gemini')) {
+    return ProviderType.GEMINI_VEO;
+  }
+
+  return defaultType;
+};
+
 /**
  * Model-to-provider mapping loaded from model_prices_and_context_window.json
  * This replaces the previous hardcoded mapping and automatically includes all
@@ -110,6 +153,11 @@ const IMAGE_MODEL_TO_PROVIDER: Record<string, ProviderType> =
 
 const VIDEO_MODEL_TO_PROVIDER: Record<string, ProviderType> =
   createVideoModelToProviderMapping();
+
+const VIDEO_MODEL_PROVIDERS: Record<
+  string,
+  Set<string>
+> = createVideoModelProviders();
 
 export const getProvider = (
   model: string,
@@ -126,7 +174,7 @@ export const getProvider = (
 
   const videoType = VIDEO_MODEL_TO_PROVIDER[model];
   if (videoType) {
-    type = videoType;
+    type = resolveVideoProviderType(model, videoType, completionPath);
   }
 
   if (model === GeminiVeoProxyPassthroughOnlyModel) {

--- a/packages/app/server/src/providers/VertexAIProvider.ts
+++ b/packages/app/server/src/providers/VertexAIProvider.ts
@@ -19,6 +19,10 @@ import { env } from '../env';
 // Constants
 export const PROXY_PASSTHROUGH_ONLY_MODEL = 'PROXY_PLACEHOLDER_VERTEX_AI';
 const VEO3_MODELS = [
+  'veo-3.1-fast-generate-001',
+  'veo-3.1-generate-001',
+  'veo-3.1-fast-generate-preview',
+  'veo-3.1-generate-preview',
   'veo-3.0-fast-generate-preview',
   'veo-3.0-generate-preview',
 ];
@@ -71,14 +75,21 @@ export class VertexAIProvider extends BaseProvider {
   }
 
   override formatUpstreamUrl(req: { path: string; url: string }): string {
-    const pathWithoutV1 = req.path.replace(/^\/v1/, '');
     const project = this.getRequiredEnvVar('GOOGLE_CLOUD_PROJECT');
     const location = env.GOOGLE_CLOUD_LOCATION || 'global';
     const queryString = req.url.includes('?')
       ? req.url.substring(req.url.indexOf('?'))
       : '';
+    const pathAfterPublisher = req.path
+      .replace(
+        /^\/v[^/]*\/projects\/[^/]+\/locations\/[^/]+\/publishers\/google/,
+        ''
+      )
+      .replace(/^\/v[^/]*\/publishers\/google/, '')
+      .replace(/^\/publishers\/google/, '')
+      .replace(/^\/v[^/]*/, '');
 
-    return `https://aiplatform.googleapis.com/v1/projects/${project}/locations/${location}${pathWithoutV1}${queryString}`;
+    return `https://aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/google${pathAfterPublisher}${queryString}`;
   }
 
   override supportsStream(): boolean {

--- a/packages/app/server/src/utils/gemini/string-parsing.ts
+++ b/packages/app/server/src/utils/gemini/string-parsing.ts
@@ -49,6 +49,13 @@ export function isFilesPath(path: string): boolean {
 
 export function extractGeminiModelName(req: Request): string | undefined {
   const path = req.path;
+  const vertexProjectPathMatch = path.match(
+    /^\/v[^/]*\/projects\/[^/]+\/locations\/[^/]+\/publishers\/google\/models\/([^/:]+)(?::predictLongRunning)?$/
+  );
+
+  if (vertexProjectPathMatch?.[1]) {
+    return vertexProjectPathMatch[1];
+  }
 
   // Expected format: /v1beta/models/{model-name}:streamGenerateContent or /v1beta/models/{model-name}:generateContent
   // OR: /models/{model-name}:streamGenerateContent or /models/{model-name}:generateContent

--- a/packages/sdk/ts/src/__tests__/video-models.test.ts
+++ b/packages/sdk/ts/src/__tests__/video-models.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { GeminiVideoModels } from '../supported-models/video/gemini';
+import { VertexAIVideoModels } from '../supported-models/video/vertex-ai';
+
+describe('video model support', () => {
+  it('includes Veo 3.1 models for Gemini and Vertex AI video generation', () => {
+    expect(GeminiVideoModels.map(model => model.model_id)).toContain(
+      'veo-3.1-generate-preview'
+    );
+    expect(GeminiVideoModels.map(model => model.model_id)).toContain(
+      'veo-3.1-fast-generate-preview'
+    );
+    expect(VertexAIVideoModels.map(model => model.model_id)).toContain(
+      'veo-3.1-generate-001'
+    );
+    expect(VertexAIVideoModels.map(model => model.model_id)).toContain(
+      'veo-3.1-fast-generate-001'
+    );
+    expect(VertexAIVideoModels.map(model => model.model_id)).toContain(
+      'veo-3.1-generate-preview'
+    );
+    expect(VertexAIVideoModels.map(model => model.model_id)).toContain(
+      'veo-3.1-fast-generate-preview'
+    );
+  });
+});

--- a/packages/sdk/ts/src/supported-models/video/gemini.ts
+++ b/packages/sdk/ts/src/supported-models/video/gemini.ts
@@ -1,10 +1,24 @@
 import { SupportedVideoModel } from 'supported-models/types';
 
 export type GeminiVideoModel =
+  | 'veo-3.1-generate-preview'
+  | 'veo-3.1-fast-generate-preview'
   | 'veo-3.0-generate-001'
   | 'veo-3.0-fast-generate-001';
 // https://ai.google.dev/gemini-api/docs/pricing
 export const GeminiVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'Gemini',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.12,
+    cost_per_second_without_audio: 0.1,
+    provider: 'Gemini',
+  },
   {
     model_id: 'veo-3.0-generate-001',
     cost_per_second_with_audio: 0.4,

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -1,16 +1,46 @@
 import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
+  | 'veo-3.1-fast-generate-001'
+  | 'veo-3.1-generate-001'
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 /**
  * Vertex AI video models with official pricing information
  * Based on: https://cloud.google.com/vertex-ai/generative-ai/pricing
  *
+ * Veo 3.1: $0.40/second with audio, $0.20/second video only
+ * Veo 3.1 Fast: $0.12/second with audio, $0.10/second video only at 1080p
  * Veo 3: $0.40/second with audio, $0.20/second video only
  * Veo 3 Fast: $0.15/second with audio, $0.10/second video only
  */
 export const VertexAIVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-fast-generate-001',
+    cost_per_second_with_audio: 0.12,
+    cost_per_second_without_audio: 0.1,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-001',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.12,
+    cost_per_second_without_audio: 0.1,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
   {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,6 +35,10 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
+    'veo-3.1-fast-generate-001',
+    'veo-3.1-generate-001',
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
   ];

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -4,6 +4,7 @@
 
 import { getEchoToken } from '@/echo';
 import { ERROR_MESSAGES } from '@/lib/constants';
+import type { VideoModelOption } from '@/lib/types';
 import {
   GenerateVideosOperation,
   GenerateVideosParameters,
@@ -14,7 +15,7 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model: VideoModelOption,
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,6 +42,10 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
+  { id: 'veo-3.1-fast-generate-001', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-001', name: 'Veo 3.1' },
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast Preview' },
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1 Preview' },
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
 ];
@@ -57,7 +61,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-001'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,6 +14,10 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
+  | 'veo-3.1-fast-generate-001'
+  | 'veo-3.1-generate-001'
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 


### PR DESCRIPTION
## Summary
- add Gemini Veo 3.1 preview video model support
- add Vertex AI Veo 3.1 GA and preview video model support with pricing
- route shared Gemini/Vertex video model IDs using request-path provider context
- update the next video template defaults/options to Veo 3.1

Fixes #595
/claim #595

## Verification
- pnpm -C packages/app/server exec vitest run src/__tests__/provider-factory.test.ts src/__tests__/string-parsing.test.ts
- pnpm -C packages/sdk/ts exec vitest run src/__tests__/video-models.test.ts
- pnpm --filter @merit-systems/echo-typescript-sdk type-check
- pnpm -C templates/next-video-template exec tsc --noEmit
- pnpm -C packages/sdk/ts exec eslint src/supported-models/video/gemini.ts src/supported-models/video/vertex-ai.ts src/__tests__/video-models.test.ts
- pnpm -C templates/next-video-template exec eslint src/app/api/generate-video/validation.ts src/app/api/generate-video/vertex.ts src/components/video-generator.tsx src/lib/types.ts
- git diff --check origin/master...HEAD

## Known Existing Repository Issues
- `pnpm -C packages/app/server type-check` still fails in `src/utils.ts` because `ExactEvmPayloadAuthorization` is declared locally in `types` but not exported. This branch does not touch that file.
- Targeted server ESLint cannot start because `packages/app/server/eslint.config.mjs` references `__dirname` in ESM scope. This branch does not touch that config.