### PR TITLE
feat: add Veo 3.1 Vertex AI video models

### DIFF
--- a/packages/app/server/src/providers/VertexAIProvider.ts
+++ b/packages/app/server/src/providers/VertexAIProvider.ts
@@ -19,6 +19,8 @@ import { env } from '../env';
 // Constants
 export const PROXY_PASSTHROUGH_ONLY_MODEL = 'PROXY_PLACEHOLDER_VERTEX_AI';
 const VEO3_MODELS = [
+  'veo-3.1-fast-generate-preview',
+  'veo-3.1-generate-preview',
   'veo-3.0-fast-generate-preview',
   'veo-3.0-generate-preview',
 ];

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.test.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { VertexAIVideoModels } from './vertex-ai';
+
+describe('VertexAIVideoModels', () => {
+  it('includes Veo 3.1 preview models with current Vertex AI pricing', () => {
+    expect(VertexAIVideoModels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          model_id: 'veo-3.1-fast-generate-preview',
+          cost_per_second_with_audio: 0.1,
+          cost_per_second_without_audio: 0.08,
+          provider: 'VertexAI',
+        }),
+        expect.objectContaining({
+          model_id: 'veo-3.1-generate-preview',
+          cost_per_second_with_audio: 0.4,
+          cost_per_second_without_audio: 0.2,
+          provider: 'VertexAI',
+        }),
+      ])
+    );
+  });
+});

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -1,16 +1,30 @@
 import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 /**
  * Vertex AI video models with official pricing information
  * Based on: https://cloud.google.com/vertex-ai/generative-ai/pricing
  *
- * Veo 3: $0.40/second with audio, $0.20/second video only
- * Veo 3 Fast: $0.15/second with audio, $0.10/second video only
+ * Veo 3.1: $0.40/second with audio, $0.20/second video only
+ * Veo 3.1 Fast: $0.10/second with audio, $0.08/second video only
  */
 export const VertexAIVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.1,
+    cost_per_second_without_audio: 0.08,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
   {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,6 +35,8 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
   ];

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -14,7 +14,11 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model:
+    | 'veo-3.1-fast-generate-preview'
+    | 'veo-3.1-generate-preview'
+    | 'veo-3.0-fast-generate-preview'
+    | 'veo-3.0-generate-preview',
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,6 +42,8 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1' },
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
 ];
@@ -57,7 +59,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-preview'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,6 +14,8 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 


### PR DESCRIPTION
## Summary
- Adds Vertex AI support for `veo-3.1-fast-generate-preview` and `veo-3.1-generate-preview`
- Adds current Vertex AI pricing for Veo 3.1 Fast and Veo 3.1 in the SDK video model registry
- Updates the Next video template model picker, request validation, handler types, and default model
- Adds a focused SDK regression test for Veo 3.1 model IDs and pricing

Fixes #595
/claim #595

## Verification
- SDK video model test passed
- SDK type-check passed
- Next video template lint passed
- Next video template build passed
- Prettier check passed for changed files
- Diff whitespace check passed

## Notes
- Server package type-check is blocked by a pre-existing `src/utils.ts` export issue after generating Prisma types.
- Server package lint is blocked before file linting by the package's ESM ESLint config using `__dirname`.