### PR TITLE
fix: reduce next-image payload size

### DIFF
--- a/templates/next-image/src/app/api/edit-image/google.ts
+++ b/templates/next-image/src/app/api/edit-image/google.ts
@@ -6,15 +6,19 @@ import { google } from '@/echo';
 import { generateText } from 'ai';
 import { getMediaTypeFromDataUrl } from '@/lib/image-utils';
 import { ERROR_MESSAGES } from '@/lib/constants';
+import { imageResponseFromBase64 } from '../image-response';
+import { editInputToDataUrl } from './image-input';
+import type { EditImageInput } from './types';
 
 /**
  * Handles Google Gemini image editing
  */
 export async function handleGoogleEdit(
   prompt: string,
-  imageUrls: string[]
+  images: EditImageInput[]
 ): Promise<Response> {
   try {
+    const imageUrls = await Promise.all(images.map(editInputToDataUrl));
     const content = [
       {
         type: 'text' as const,
@@ -48,9 +52,10 @@ export async function handleGoogleEdit(
       );
     }
 
-    return Response.json({
-      imageUrl: `data:${imageFile.mediaType};base64,${imageFile.base64}`,
-    });
+    return imageResponseFromBase64(
+      imageFile.base64,
+      imageFile.mediaType || 'image/png'
+    );
   } catch (error) {
     console.error('Google image editing error:', error);
     return Response.json(

--- a/templates/next-image/src/app/api/edit-image/image-input.ts
+++ b/templates/next-image/src/app/api/edit-image/image-input.ts
@@ -1,0 +1,22 @@
+import { dataUrlToFile } from '@/lib/image-utils';
+import type { EditImageInput } from './types';
+
+export async function editInputToDataUrl(
+  image: EditImageInput
+): Promise<string> {
+  if (typeof image === 'string') {
+    return image;
+  }
+
+  const buffer = Buffer.from(await image.arrayBuffer());
+  const mediaType = image.type || 'image/jpeg';
+  return `data:${mediaType};base64,${buffer.toString('base64')}`;
+}
+
+export function editInputToFile(image: EditImageInput, index: number): File {
+  if (typeof image !== 'string') {
+    return image;
+  }
+
+  return dataUrlToFile(image, `image-${index}.png`);
+}

--- a/templates/next-image/src/app/api/edit-image/openai.ts
+++ b/templates/next-image/src/app/api/edit-image/openai.ts
@@ -4,15 +4,17 @@
 
 import { getEchoToken } from '@/echo';
 import OpenAI from 'openai';
-import { dataUrlToFile } from '@/lib/image-utils';
 import { ERROR_MESSAGES } from '@/lib/constants';
+import { imageResponseFromBase64 } from '../image-response';
+import { editInputToFile } from './image-input';
+import type { EditImageInput } from './types';
 
 /**
  * Handles OpenAI image editing
  */
 export async function handleOpenAIEdit(
   prompt: string,
-  imageUrls: string[]
+  images: EditImageInput[]
 ): Promise<Response> {
   const token = await getEchoToken();
 
@@ -32,7 +34,7 @@ export async function handleOpenAIEdit(
   });
 
   try {
-    const imageFiles = imageUrls.map(url => dataUrlToFile(url, 'image.png'));
+    const imageFiles = images.map(editInputToFile);
 
     const result = await openaiClient.images.edit({
       image: imageFiles,
@@ -49,9 +51,15 @@ export async function handleOpenAIEdit(
       );
     }
 
-    return Response.json({
-      imageUrl: `data:image/png;base64,${result.data[0]?.b64_json}`,
-    });
+    const imageBase64 = result.data[0]?.b64_json;
+    if (!imageBase64) {
+      return Response.json(
+        { error: ERROR_MESSAGES.NO_EDITED_IMAGE },
+        { status: 500 }
+      );
+    }
+
+    return imageResponseFromBase64(imageBase64, 'image/png');
   } catch (error) {
     console.error('OpenAI image editing error:', error);
     return Response.json(

--- a/templates/next-image/src/app/api/edit-image/route.ts
+++ b/templates/next-image/src/app/api/edit-image/route.ts
@@ -3,32 +3,99 @@
  *
  * This route demonstrates Echo SDK integration with AI image editing:
  * - Uses both Google Gemini and OpenAI for image editing
- * - Supports both data URLs (base64) and regular URLs
+ * - Supports multipart image uploads and legacy data URL JSON requests
  * - Validates input images and prompts
  * - Returns edited images in appropriate format
  */
 
-import { EditImageRequest, validateEditImageRequest } from './validation';
+import type { EditImageRequest } from './validation';
+import {
+  MAX_EDIT_IMAGE_BYTES,
+  validateEditImageFields,
+  validateEditImageRequest,
+} from './validation';
 import { handleGoogleEdit } from './google';
 import { handleOpenAIEdit } from './openai';
+import type { ModelOption } from '@/lib/types';
 
 const providers = {
   openai: handleOpenAIEdit,
   gemini: handleGoogleEdit,
 };
 
-export const config = {
-  api: {
-    bodyParser: {
-      sizeLimit: '4mb',
-    },
-  },
-};
+export const maxDuration = 60;
+
+type ParsedMultipartEditRequest =
+  | {
+      ok: true;
+      prompt: string;
+      provider: ModelOption;
+      images: File[];
+    }
+  | {
+      ok: false;
+      error: { message: string; status: number };
+    };
+
+async function parseMultipartEditRequest(
+  req: Request
+): Promise<ParsedMultipartEditRequest> {
+  const formData = await req.formData();
+  const prompt = formData.get('prompt');
+  const provider = formData.get('provider');
+  const imageFiles = formData
+    .getAll('images')
+    .filter((value): value is File => value instanceof File && value.size > 0);
+
+  const validation = validateEditImageFields({
+    prompt,
+    provider,
+    imageCount: imageFiles.length,
+  });
+
+  if (!validation.isValid) {
+    return { ok: false, error: validation.error! };
+  }
+
+  const totalBytes = imageFiles.reduce((total, file) => total + file.size, 0);
+  if (totalBytes > MAX_EDIT_IMAGE_BYTES) {
+    return {
+      ok: false,
+      error: {
+        message:
+          'Uploaded images are too large. Please use smaller images or fewer attachments.',
+        status: 413,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    prompt: prompt as string,
+    provider: provider as ModelOption,
+    images: imageFiles,
+  };
+}
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
+    const contentType = req.headers.get('content-type') ?? '';
 
+    if (contentType.includes('multipart/form-data')) {
+      const parsed = await parseMultipartEditRequest(req);
+
+      if (!parsed.ok) {
+        return Response.json(
+          { error: parsed.error.message },
+          { status: parsed.error.status }
+        );
+      }
+
+      const handler = providers[parsed.provider];
+      return handler(parsed.prompt, parsed.images);
+    }
+
+    const body = await req.json();
     const validation = validateEditImageRequest(body);
     if (!validation.isValid) {
       return Response.json(

--- a/templates/next-image/src/app/api/edit-image/types.ts
+++ b/templates/next-image/src/app/api/edit-image/types.ts
@@ -1,0 +1,1 @@
+export type EditImageInput = File | string;

--- a/templates/next-image/src/app/api/edit-image/validation.ts
+++ b/templates/next-image/src/app/api/edit-image/validation.ts
@@ -7,16 +7,19 @@ export interface ValidationResult {
   error?: { message: string; status: number };
 }
 
-export function validateEditImageRequest(body: unknown): ValidationResult {
-  if (!body || typeof body !== 'object') {
-    return {
-      isValid: false,
-      error: { message: 'Invalid request body', status: 400 },
-    };
-  }
+export interface EditImageFields {
+  prompt: unknown;
+  provider: unknown;
+  imageCount: number;
+}
 
-  const { prompt, imageUrls, provider } = body as Record<string, unknown>;
+export const MAX_EDIT_IMAGE_BYTES = 4 * 1024 * 1024;
 
+export function validateEditImageFields({
+  prompt,
+  provider,
+  imageCount,
+}: EditImageFields): ValidationResult {
   const validProviders: ModelOption[] = ['openai', 'gemini'];
   if (!provider || !validProviders.includes(provider as ModelOption)) {
     return {
@@ -42,6 +45,26 @@ export function validateEditImageRequest(body: unknown): ValidationResult {
     };
   }
 
+  if (imageCount === 0) {
+    return {
+      isValid: false,
+      error: { message: 'At least one image is required', status: 400 },
+    };
+  }
+
+  return { isValid: true };
+}
+
+export function validateEditImageRequest(body: unknown): ValidationResult {
+  if (!body || typeof body !== 'object') {
+    return {
+      isValid: false,
+      error: { message: 'Invalid request body', status: 400 },
+    };
+  }
+
+  const { prompt, imageUrls, provider } = body as Record<string, unknown>;
+
   if (!imageUrls || !Array.isArray(imageUrls) || imageUrls.length === 0) {
     return {
       isValid: false,
@@ -56,5 +79,9 @@ export function validateEditImageRequest(body: unknown): ValidationResult {
     };
   }
 
-  return { isValid: true };
+  return validateEditImageFields({
+    prompt,
+    provider,
+    imageCount: imageUrls.length,
+  });
 }

--- a/templates/next-image/src/app/api/generate-image/google.ts
+++ b/templates/next-image/src/app/api/generate-image/google.ts
@@ -5,6 +5,7 @@
 import { google } from '@/echo';
 import { generateText } from 'ai';
 import { ERROR_MESSAGES } from '@/lib/constants';
+import { imageResponseFromBase64 } from '../image-response';
 
 /**
  * Handles Google Gemini image generation
@@ -27,9 +28,10 @@ export async function handleGoogleGenerate(prompt: string): Promise<Response> {
       );
     }
 
-    return Response.json({
-      imageUrl: `data:${imageFile.mediaType};base64,${imageFile.base64}`,
-    });
+    return imageResponseFromBase64(
+      imageFile.base64,
+      imageFile.mediaType || 'image/png'
+    );
   } catch (error) {
     console.error('Google image generation error:', error);
     return Response.json(

--- a/templates/next-image/src/app/api/generate-image/openai.ts
+++ b/templates/next-image/src/app/api/generate-image/openai.ts
@@ -5,6 +5,7 @@
 import { openai } from '@/echo';
 import { experimental_generateImage as generateImage } from 'ai';
 import { ERROR_MESSAGES } from '@/lib/constants';
+import { imageResponseFromBase64 } from '../image-response';
 
 /**
  * Handles OpenAI image generation
@@ -17,9 +18,7 @@ export async function handleOpenAIGenerate(prompt: string): Promise<Response> {
     });
 
     const imageData = result.image;
-    return Response.json({
-      imageUrl: `data:${imageData.mediaType};base64,${imageData.base64}`,
-    });
+    return imageResponseFromBase64(imageData.base64, imageData.mediaType);
   } catch (error) {
     console.error('OpenAI image generation error:', error);
     return Response.json(

--- a/templates/next-image/src/app/api/generate-image/route.ts
+++ b/templates/next-image/src/app/api/generate-image/route.ts
@@ -19,13 +19,7 @@ const providers = {
   gemini: handleGoogleGenerate,
 };
 
-export const config = {
-  api: {
-    bodyParser: {
-      sizeLimit: '4mb',
-    },
-  },
-};
+export const maxDuration = 60;
 
 export async function POST(req: Request) {
   try {

--- a/templates/next-image/src/app/api/image-response.ts
+++ b/templates/next-image/src/app/api/image-response.ts
@@ -1,0 +1,17 @@
+/**
+ * Utilities for returning generated images without base64 JSON payloads.
+ */
+
+export function imageResponseFromBase64(
+  base64: string,
+  mediaType: string
+): Response {
+  const bytes = Buffer.from(base64, 'base64');
+
+  return new Response(new Blob([new Uint8Array(bytes)], { type: mediaType }), {
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': mediaType,
+    },
+  });
+}

--- a/templates/next-image/src/components/image-details-dialog.tsx
+++ b/templates/next-image/src/components/image-details-dialog.tsx
@@ -30,10 +30,10 @@ export function ImageDetailsDialog({
   onClose,
   onAddToInput,
 }: ImageDetailsDialogProps) {
-  const handleAddToInput = useCallback(() => {
+  const handleAddToInput = useCallback(async () => {
     if (!image || !isImageActionable(image)) return;
 
-    const file = handleImageToFile(image.imageUrl!, image.id);
+    const file = await handleImageToFile(image.imageUrl!, image.id);
     onAddToInput([file]);
     onClose();
   }, [image, onAddToInput, onClose]);

--- a/templates/next-image/src/components/image-generator.tsx
+++ b/templates/next-image/src/components/image-generator.tsx
@@ -25,9 +25,8 @@ import { Button } from '@/components/ui/button';
 import { X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { fileToDataUrl } from '@/lib/image-utils';
+import { compressImageFile, fileToDataUrl } from '@/lib/image-utils';
 import type {
-  EditImageRequest,
   GeneratedImage,
   GenerateImageRequest,
   ImageResponse,
@@ -60,6 +59,29 @@ const models: ModelConfig[] = [
  */
 
 // ===== API FUNCTIONS =====
+async function parseImageResponse(response: Response): Promise<ImageResponse> {
+  if (!response.ok) {
+    const errorText = await response.text();
+    let error = errorText;
+
+    try {
+      error = JSON.parse(errorText).error || errorText;
+    } catch {
+      // Keep the original response text when the server returns a plain error.
+    }
+
+    throw new Error(`HTTP ${response.status}: ${error}`);
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+
+  const blob = await response.blob();
+  return { imageUrl: URL.createObjectURL(blob) };
+}
+
 async function generateImage(
   request: GenerateImageRequest
 ): Promise<ImageResponse> {
@@ -69,27 +91,28 @@ async function generateImage(
     body: JSON.stringify(request),
   });
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`HTTP ${response.status}: ${errorText}`);
-  }
-
-  return response.json();
+  return parseImageResponse(response);
 }
 
-async function editImage(request: EditImageRequest): Promise<ImageResponse> {
-  const response = await fetch('/api/edit-image', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(request),
-  });
+async function editImage(request: {
+  prompt: string;
+  imageFiles: File[];
+  provider: ModelOption;
+}): Promise<ImageResponse> {
+  const formData = new FormData();
+  formData.set('prompt', request.prompt);
+  formData.set('provider', request.provider);
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  for (const imageFile of request.imageFiles) {
+    formData.append('images', imageFile, imageFile.name);
   }
 
-  return response.json();
+  const response = await fetch('/api/edit-image', {
+    method: 'POST',
+    body: formData,
+  });
+
+  return parseImageResponse(response);
 }
 
 /**
@@ -217,20 +240,21 @@ export default function ImageGenerator() {
           }
 
           try {
-            const imageUrls = await Promise.all(
+            const uploadedImages = await Promise.all(
               imageFiles.map(async imageFile => {
-                // Convert blob URL to data URL for API
                 const response = await fetch(imageFile.url);
                 const blob = await response.blob();
-                return await fileToDataUrl(
-                  new File([blob], 'image', { type: imageFile.mediaType })
+                return await compressImageFile(
+                  new File([blob], imageFile.filename || 'image', {
+                    type: imageFile.mediaType,
+                  })
                 );
               })
             );
 
             const result = await editImage({
               prompt,
-              imageUrls,
+              imageFiles: uploadedImages,
               provider: model,
             });
             imageUrl = result.imageUrl;

--- a/templates/next-image/src/components/image-history.tsx
+++ b/templates/next-image/src/components/image-history.tsx
@@ -50,10 +50,10 @@ const ImageHistoryItem = React.memo(function ImageHistoryItem({
   onAddToInput,
   onImageClick,
 }: ImageHistoryItemProps) {
-  const handleAddToInput = useCallback(() => {
+  const handleAddToInput = useCallback(async () => {
     if (!isImageActionable(image)) return;
 
-    const file = handleImageToFile(image.imageUrl!, image.id);
+    const file = await handleImageToFile(image.imageUrl!, image.id);
     onAddToInput([file]);
   }, [image, onAddToInput]);
 

--- a/templates/next-image/src/lib/image-actions.ts
+++ b/templates/next-image/src/lib/image-actions.ts
@@ -4,10 +4,10 @@
  */
 
 import {
-  dataUrlToFile,
   downloadDataUrl,
   copyDataUrlToClipboard,
   generateFilename,
+  imageUrlToFile,
 } from './image-utils';
 import type { GeneratedImage } from './types';
 
@@ -29,9 +29,12 @@ export async function handleImageCopy(imageUrl: string): Promise<void> {
 /**
  * Converts image data to a File object for adding to input
  */
-export function handleImageToFile(imageUrl: string, imageId: string): File {
+export async function handleImageToFile(
+  imageUrl: string,
+  imageId: string
+): Promise<File> {
   const filename = generateFilename(imageId);
-  return dataUrlToFile(imageUrl, filename);
+  return imageUrlToFile(imageUrl, filename);
 }
 
 /**

--- a/templates/next-image/src/lib/image-utils.ts
+++ b/templates/next-image/src/lib/image-utils.ts
@@ -1,7 +1,7 @@
 /**
  * Minimal Image Utilities
  *
- * Simple, clean API with just data URLs. No complex conversions.
+ * Simple helpers for browser image URLs and file conversion.
  */
 
 /**
@@ -14,6 +14,92 @@ export async function fileToDataUrl(file: File): Promise<string> {
     reader.onerror = reject;
     reader.readAsDataURL(file);
   });
+}
+
+const DEFAULT_MAX_IMAGE_DIMENSION = 1024;
+const DEFAULT_IMAGE_QUALITY = 0.85;
+const COMPRESS_SKIP_BYTES = 512 * 1024;
+
+interface CompressImageOptions {
+  maxDimension?: number;
+  quality?: number;
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = reject;
+    image.src = src;
+  });
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number
+): Promise<Blob | null> {
+  return new Promise(resolve => {
+    canvas.toBlob(resolve, type, quality);
+  });
+}
+
+/**
+ * Compresses large image files before they are sent to API routes.
+ *
+ * The next-image template used to send raw base64 in JSON requests. Large
+ * source images can exceed platform request limits before the API route runs,
+ * so edit requests should send this smaller File via multipart form data.
+ */
+export async function compressImageFile(
+  file: File,
+  options: CompressImageOptions = {}
+): Promise<File> {
+  const maxDimension = options.maxDimension ?? DEFAULT_MAX_IMAGE_DIMENSION;
+  const quality = options.quality ?? DEFAULT_IMAGE_QUALITY;
+
+  if (!file.type.startsWith('image/') || file.type === 'image/svg+xml') {
+    return file;
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+
+  try {
+    const image = await loadImage(objectUrl);
+    const largestSide = Math.max(image.naturalWidth, image.naturalHeight);
+    const scale = largestSide > maxDimension ? maxDimension / largestSide : 1;
+
+    if (scale === 1 && file.size <= COMPRESS_SKIP_BYTES) {
+      return file;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round(image.naturalWidth * scale));
+    canvas.height = Math.max(1, Math.round(image.naturalHeight * scale));
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return file;
+    }
+
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+    const blob = await canvasToBlob(canvas, 'image/jpeg', quality);
+    if (!blob || blob.size >= file.size) {
+      return file;
+    }
+
+    const filename = file.name.replace(/\.[^.]*$/, '') || 'image';
+    return new File([blob], `${filename}.jpg`, {
+      type: blob.type,
+      lastModified: file.lastModified,
+    });
+  } catch (error) {
+    console.warn('Image compression failed, using original file:', error);
+    return file;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
 }
 
 /**
@@ -33,22 +119,24 @@ export function dataUrlToFile(dataUrl: string, filename: string): File {
 }
 
 /**
- * Downloads an image from a data URL
+ * Downloads an image from a browser-readable URL.
  */
-export function downloadDataUrl(dataUrl: string, filename: string): void {
+export function downloadDataUrl(imageUrl: string, filename: string): void {
   const link = document.createElement('a');
-  link.href = dataUrl;
+  link.href = imageUrl;
   link.download = filename;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
 }
 
-/**
- * Copies an image to the clipboard from a data URL
- */
-export async function copyDataUrlToClipboard(dataUrl: string): Promise<void> {
-  const [header, base64] = dataUrl.split(',');
+async function imageUrlToBlob(imageUrl: string): Promise<Blob> {
+  if (!imageUrl.startsWith('data:')) {
+    const response = await fetch(imageUrl);
+    return response.blob();
+  }
+
+  const [header, base64] = imageUrl.split(',');
   const mime = header.match(/:(.*?);/)?.[1] || 'image/png';
   const bytes = atob(base64);
   const array = new Uint8Array(bytes.length);
@@ -57,7 +145,23 @@ export async function copyDataUrlToClipboard(dataUrl: string): Promise<void> {
     array[i] = bytes.charCodeAt(i);
   }
 
-  const blob = new Blob([array], { type: mime });
+  return new Blob([array], { type: mime });
+}
+
+export async function imageUrlToFile(
+  imageUrl: string,
+  filename: string
+): Promise<File> {
+  const blob = await imageUrlToBlob(imageUrl);
+  return new File([blob], filename, { type: blob.type || 'image/png' });
+}
+
+/**
+ * Copies an image to the clipboard from a browser-readable URL.
+ */
+export async function copyDataUrlToClipboard(imageUrl: string): Promise<void> {
+  const blob = await imageUrlToBlob(imageUrl);
+  const mime = blob.type || 'image/png';
   await navigator.clipboard.write([new ClipboardItem({ [mime]: blob })]);
 }
 

--- a/templates/next-image/src/lib/types.ts
+++ b/templates/next-image/src/lib/types.ts
@@ -22,7 +22,7 @@ export interface ModelConfig {
 export interface GeneratedImage {
   /** Unique identifier for the image */
   id: string;
-  /** The actual image as data URL (undefined if still loading or error) */
+  /** Browser-readable image URL (undefined if still loading or error) */
   imageUrl?: string;
   /** User prompt that generated this image */
   prompt: string;
@@ -49,7 +49,8 @@ export interface GenerateImageRequest {
 }
 
 /**
- * Request payload for image editing API
+ * Legacy JSON request payload for image editing API.
+ * The browser UI sends multipart uploads to avoid large base64 JSON bodies.
  */
 export interface EditImageRequest {
   prompt: string;
@@ -58,10 +59,10 @@ export interface EditImageRequest {
 }
 
 /**
- * Response from image generation/editing APIs
+ * Parsed response from image generation/editing APIs
  */
 export interface ImageResponse {
-  imageUrl: string; // data URL
+  imageUrl: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #561.

This updates the `templates/next-image` flow so image payloads are not passed between the browser and Next routes as base64 JSON:

- edit requests now send multipart `File` uploads instead of data URL JSON
- large edit attachments are resized/re-encoded in the browser before upload
- generate/edit routes return binary image responses instead of JSON-wrapped base64 data URLs
- OpenAI edits receive uploaded `File` objects directly on the multipart path
- legacy JSON edit requests remain supported for callers still sending data URLs

Validation:

- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec prettier --check ...`
- `git diff --check`
- `corepack pnpm run lint`
- `corepack pnpm run build`

`next lint` and `next build` still report the pre-existing warnings in `src/app/page.tsx` and `src/components/logo.tsx`.

/claim #561
