### PR TITLE
feat(templates): add Chat x402 template with Echo Credits / USDC payment switcher (closes #610)

### DIFF
--- a/templates/chat-x402/src/app/_components/chat-x402.tsx
+++ b/templates/chat-x402/src/app/_components/chat-x402.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { useState } from 'react';
+import { Loader } from '@/components/ai-elements/loader';
+import { Message, MessageContent } from '@/components/ai-elements/message';
+import {
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+} from '@/components/ai-elements/prompt-input';
+
+type PaymentMethod = 'echo' | 'usdc';
+
+interface AuthSwitcherProps {
+  currentMethod: PaymentMethod;
+  onSwitch: (method: PaymentMethod) => void;
+}
+
+function AuthSwitcher({ currentMethod, onSwitch }: AuthSwitcherProps) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-gray-100 p-2 dark:bg-gray-800">
+      <span className="text-sm text-gray-600 dark:text-gray-400">
+        Pay with:
+      </span>
+      <button
+        onClick={() => onSwitch('echo')}
+        className={`rounded-md px-3 py-1 text-sm transition-colors ${
+          currentMethod === 'echo'
+            ? 'bg-blue-500 text-white'
+            : 'bg-white text-gray-700 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+        }`}
+      >
+        Echo Credits
+      </button>
+      <button
+        onClick={() => onSwitch('usdc')}
+        className={`rounded-md px-3 py-1 text-sm transition-colors ${
+          currentMethod === 'usdc'
+            ? 'bg-blue-500 text-white'
+            : 'bg-white text-gray-700 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+        }`}
+      >
+        USDC (x402)
+      </button>
+    </div>
+  );
+}
+
+const ChatX402 = () => {
+  const [input, setInput] = useState('');
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('echo');
+  const { messages, sendMessage, status, error } = useChat({
+    api: '/api/chat-x402',
+    body: {
+      paymentMethod,
+    },
+    onError: (err) => {
+      console.error('Chat error:', err);
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (input.trim() && status !== 'streaming') {
+      sendMessage({ text: input });
+      setInput('');
+    }
+  };
+
+  return (
+    <div className="mx-auto flex h-full max-w-3xl flex-col gap-4 p-4">
+      <AuthSwitcher
+        currentMethod={paymentMethod}
+        onSwitch={setPaymentMethod}
+      />
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400">
+          {error.message.includes('402')
+            ? 'Payment required. Please add funds to continue.'
+            : error.message}
+        </div>
+      )}
+
+      <div className="flex-1 space-y-4 overflow-y-auto">
+        {messages.map((message) => (
+          <Message key={message.id} from={message.role === 'user' ? 'user' : 'assistant'}>
+            <MessageContent>{message.content}</MessageContent>
+          </Message>
+        ))}
+        {status === 'streaming' && <Loader />}
+      </div>
+
+      <form onSubmit={handleSubmit} className="sticky bottom-0">
+        <PromptInput>
+          <PromptInputTextarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type a message..."
+          />
+          <PromptInputSubmit disabled={!input.trim() || status === 'streaming'} />
+        </PromptInput>
+      </form>
+    </div>
+  );
+};
+
+export default ChatX402;

--- a/templates/chat-x402/src/app/api/chat-x402/route.ts
+++ b/templates/chat-x402/src/app/api/chat-x402/route.ts
@@ -1,0 +1,34 @@
+import { anthropic, openai } from '@/echo';
+import { x402 } from '@merit-systems/echo-aix402';
+
+export async function POST(req: Request) {
+  const { messages, paymentMethod } = await req.json();
+
+  // x402 payment verification
+  if (paymentMethod === 'usdc') {
+    const paymentVerified = await x402.verifyPayment(req);
+    if (!paymentVerified) {
+      return new Response(
+        JSON.stringify({ error: 'Payment required', status: 402 }),
+        {
+          status: 402,
+          headers: {
+            'Content-Type': 'application/json',
+            'x402-payment-required': 'true',
+            'x402-accept': 'usdc',
+            'x402-amount': '0.01',
+            'x402-network': 'base',
+          },
+        }
+      );
+    }
+  }
+
+  // Use Echo-billed AI providers
+  const result = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages,
+  });
+
+  return result.toDataStreamResponse();
+}


### PR DESCRIPTION
## Description

Add Chat x402 template as requested in [#610](https://github.com/Merit-Systems/echo/issues/610).

Reuses the existing AI elements from next-chat template and merges the x402 payment flow as specified by [@rsproule](https://github.com/rsproule).

### What's included:

**Auth/Payment Switcher:**
- `AuthSwitcher` component allowing users to choose between Echo Credits and USDC (x402)
- Clean toggle UI consistent with Echo's design system
- Payment method passed to API route via request body

**Chat Component (`chat-x402.tsx`):**
- Reuses AI elements from next-chat template (`Message`, `PromptInput`, `Loader`)
- Integrated x402 payment error handling (HTTP 402)
- Payment-required UI feedback when funds are insufficient
- Dark mode support with Tailwind dark: classes

**API Route (`chat-x402/route.ts`):**
- x402 payment verification via `@merit-systems/echo-aix402`
- HTTP 402 response with payment headers when USDC payment is required
- Echo-billed AI providers for both payment methods
- Standard x402 headers: `x402-payment-required`, `x402-accept`, `x402-amount`, `x402-network`

### Implementation Notes

- Built following [rsproule's guidance](https://github.com/Merit-Systems/echo/issues/610#issuecomment-2351732158): "reuse the existing one as much as possible. And merge the login flow from the sora template"
- Reuses `Message`, `MessageContent`, `PromptInput`, `PromptInputTextarea`, `PromptInputSubmit`, `Loader` from next-chat AI elements
- Echo SDK handles billing automatically for Echo Credits method
- x402 protocol handles USDC payment verification

### Files

- `templates/chat-x402/src/app/_components/chat-x402.tsx` — Chat component with auth switcher
- `templates/chat-x402/src/app/api/chat-x402/route.ts` — API route with x402 payment handling

Closes [#610](https://github.com/Merit-Systems/echo/issues/610)