### PR TITLE
docs: add Echo Cursor rules to templates

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -236,6 +236,7 @@ Each template follows a consistent structure:
 
 ```
 template-name/
+├── .cursor/rules/echo_rules.mdc # Cursor rules tailored to the template stack
 ├── src/                  # Source code
 │   ├── app/             # Application pages (Next.js)
 │   ├── components/      # React components

--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo and Assistant UI rules for the assistant-ui template
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+# Echo Assistant UI Guidelines
+
+## Assistant architecture
+- Keep Echo route handling in `app/api/echo/[...path]/route.ts`.
+- Keep assistant chat streaming in `app/api/chat/route.ts`.
+- Use the configured Echo-backed provider for model calls instead of direct provider clients.
+- Preserve Assistant UI thread, message, and tool component contracts when modifying the UI.
+
+## Echo usage
+- Keep Echo app configuration in the existing `echo.ts` file.
+- Do not expose API keys, Echo credentials, or wallet information to client components.
+- Surface sign-in, balance, and billing failures in the assistant UI with recoverable states.
+- Keep usage-triggering actions behind explicit user actions.
+
+## Component rules
+- Reuse existing `components/assistant-ui/**` components before adding new ones.
+- Keep markdown rendering and tool fallbacks safe for untrusted model output.
+- Maintain accessible buttons, tooltips, focus states, and loading indicators.
+- Keep server-only logic out of `"use client"` components.

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo and Auth.js provider rules for the Auth.js template
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+# Echo Auth.js Guidelines
+
+## Auth architecture
+- Keep Auth.js configuration in `src/auth/index.ts`.
+- Keep Echo provider and client logic in `src/lib/echo-client.ts` and `src/echo/index.ts`.
+- Use server session helpers for protected pages and server routes.
+- Keep client components limited to rendering session-dependent UI.
+
+## Echo usage
+- Use Echo as the configured Auth.js provider instead of adding duplicate auth flows.
+- Store client IDs, client secrets, app IDs, and callback URLs in environment variables.
+- Never expose provider secrets or tokens to browser components.
+- Handle signed-out, expired-session, and denied-access states explicitly.
+
+## Implementation rules
+- Preserve Auth.js route handler conventions in `src/app/api/auth/[...nextauth]/route.ts`.
+- Validate callback and redirect behavior when changing auth configuration.
+- Keep dashboard pages server-rendered unless interactivity requires a client component.
+- Update template docs when auth setup steps change.

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo CLI rules for the Echodex command-line template
+globs: **/*.{ts,js}
+---
+
+# Echo CLI Guidelines
+
+## CLI architecture
+- Keep command registration in `src/index.ts`.
+- Keep auth flows in `src/auth/**`, core chat/history/profile behavior in `src/core/**`, and reusable helpers in `src/utils/**`.
+- Keep configuration constants in `src/constants.ts` and typed config modules.
+- Preserve non-interactive command behavior for scripts and CI.
+
+## Echo usage
+- Support Echo API key, WalletConnect, and local wallet flows without mixing credential storage paths.
+- Store API keys and private keys only through the OS keychain helpers.
+- Never log secrets, private keys, raw auth tokens, or signed payloads.
+- Keep X402 and wallet payment flows explicit and user-confirmed.
+
+## Implementation rules
+- Validate command inputs with existing Zod schemas before executing actions.
+- Keep long-running network or wallet calls cancellable and visibly pending.
+- Return actionable errors for auth, network, balance, and provider failures.
+- Keep conversation history export free of secrets and local credential metadata.

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo, Next.js, and AI SDK rules for the chat template
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+# Echo Next.js Chat Guidelines
+
+## Chat architecture
+- Keep Echo configuration in `src/echo/index.ts`.
+- Keep chat transport and model calls in `src/app/api/chat/route.ts` or nearby server modules.
+- Use Echo-wrapped providers for streamed model responses so usage is billed and tracked.
+- Preserve the template's AI SDK message shapes when changing chat state or route handlers.
+
+## Echo billing and auth
+- Do not call OpenAI, Anthropic, or other model providers directly from browser components.
+- Use Echo account, balance, and sign-in components already present in the template.
+- Show a clear empty, loading, error, and insufficient-balance state for paid chat actions.
+- Never store API keys, Echo app IDs, or wallet secrets in component state or committed files.
+
+## UI rules
+- Keep chat controls responsive and keyboard accessible.
+- Preserve streaming behavior when adding tools, attachments, or citations.
+- Keep money and balance display formatting centralized in the existing currency helpers.
+- Prefer existing shadcn/ui and AI element components over adding new UI primitives.

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo and Next.js image-generation template rules
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+# Echo Next.js Image Guidelines
+
+## Image-generation flow
+- Keep provider calls in `src/app/api/generate-image/route.ts` and `src/app/api/edit-image/route.ts`.
+- Validate prompts, image inputs, model options, and file payloads before invoking providers.
+- Use Echo-wrapped provider flows so each image generation or edit is billed and tracked.
+- Keep generated image history and UI state in the existing hooks and components.
+
+## Echo usage
+- Keep Echo configuration in `src/echo/index.ts`.
+- Do not call image providers directly from browser components.
+- Show balance, sign-in, insufficient-credit, loading, and provider-error states clearly.
+- Never commit API keys, Echo credentials, wallet secrets, or generated private data.
+
+## UI rules
+- Reuse existing image generator, history, details dialog, and Echo account components.
+- Keep image previews responsive and avoid layout shifts while generation is pending.
+- Make download and details actions explicit buttons.
+- Keep currency formatting in shared helpers.

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo and Next.js video-generation template rules
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+# Echo Next.js Video Guidelines
+
+## Video-generation flow
+- Keep video provider calls in `src/app/api/generate-video/route.ts` and status polling in `src/app/api/check-video-status/route.ts`.
+- Validate prompt text, image inputs, duration, aspect ratio, and model options before billing work.
+- Use Echo-backed provider calls so video generation is billed and usage is tracked.
+- Keep long-running job state in existing video hooks and history helpers.
+
+## Echo usage
+- Keep Echo configuration in `src/echo/index.ts`.
+- Do not expose provider keys, Echo secrets, wallet data, or raw payment details to client code.
+- Handle pending, failed, timeout, insufficient-balance, and completed states explicitly.
+- Avoid duplicate billing by making retry and polling behavior idempotent.
+
+## UI rules
+- Reuse existing video generator, history, details dialog, and Echo account components.
+- Keep preview containers stable while jobs are running.
+- Make file uploads, generation, cancel, refresh, and download actions accessible.
+- Keep currency formatting in shared helpers.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo and Next.js App Router rules for the minimal Echo starter template
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+# Echo Next.js Guidelines
+
+## App structure
+- Keep Echo setup in `src/echo/index.ts` and import the exported Echo helpers from there.
+- Use App Router conventions for pages, layouts, and route handlers.
+- Keep server-only Echo calls in server components, server actions, or `app/api/**/route.ts`.
+- Keep client components marked with `"use client"` when they use hooks, browser APIs, or interactive Echo UI.
+
+## Echo usage
+- Use the configured Echo SDK exports instead of constructing duplicate Echo clients.
+- Keep `ECHO_APP_ID` and other secrets in environment variables, never inline credentials in components.
+- Route user-facing paid AI calls through Echo so balance, auth, and usage tracking stay consistent.
+- Surface Echo auth and billing errors as actionable UI states instead of swallowing them.
+
+## Implementation style
+- Prefer small server route handlers over putting network logic directly in UI components.
+- Validate request payloads before calling model providers.
+- Keep generated UI accessible with semantic buttons, labels, loading states, and error states.
+- Do not bypass Echo billing with direct provider SDK calls unless the template explicitly documents it.

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo, Next.js, Prisma, and API key management rules
+globs: **/*.{ts,tsx,js,jsx,prisma}
+---
+
+# Echo API Key Template Guidelines
+
+## API key architecture
+- Keep API key creation, validation, and storage on the server.
+- Use Prisma models and migrations for database changes.
+- Never expose plaintext API keys after initial creation.
+- Hash or otherwise protect API keys before persistence.
+
+## Echo usage
+- Keep Echo configuration in `src/echo/index.ts`.
+- Route paid AI calls through Echo-backed server routes.
+- Keep Echo app IDs, provider secrets, database URLs, and API-key secrets in environment variables.
+- Return clear auth, quota, and insufficient-balance errors from API routes.
+
+## Implementation rules
+- Validate request bodies before reading or writing database records.
+- Keep user/account lookup logic centralized in existing helpers.
+- Avoid putting database or provider calls in client components.
+- Update README and `env.example` when adding required configuration.

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo, Vite React, and AI SDK rules for the chat template
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+# Echo React Chat Guidelines
+
+## Chat architecture
+- Keep Echo client setup in `src/echo/index.ts`.
+- Keep chat state in existing chat components and hooks.
+- Use Echo React SDK APIs for auth, balance, and paid model calls.
+- Preserve message shape compatibility with the AI element components.
+
+## Echo usage
+- Do not ship provider API keys or wallet secrets in client-side Vite code.
+- Use `VITE_` environment variables only for public Echo app configuration.
+- Show clear sign-in, insufficient-balance, streaming, failed-send, and retry states.
+- Avoid triggering paid calls automatically on page load.
+
+## UI rules
+- Reuse existing chat, balance, Echo account, and AI element components.
+- Keep streaming UI responsive and keyboard accessible.
+- Keep money formatting in shared currency helpers.
+- Validate prompt input before starting a paid request.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo and Vite React image-generation template rules
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+# Echo React Image Guidelines
+
+## Image-generation flow
+- Keep Echo client setup in `src/echo/index.ts`.
+- Keep image generation UI in the existing image components.
+- Validate prompt text, image options, and selected files before starting paid work.
+- Keep image previews and history state in the existing component structure.
+
+## Echo usage
+- Use Echo React SDK flows for auth, balance, and paid image actions.
+- Do not commit provider API keys, wallet private keys, or server secrets into Vite code.
+- Use `VITE_` environment variables only for public Echo app configuration.
+- Show sign-in, balance, loading, insufficient-credit, and provider-error states.
+
+## UI rules
+- Reuse existing Echo account, balance, image generation, and history components.
+- Keep previews responsive and stable while generation is pending.
+- Make download and details actions explicit.
+- Keep currency formatting in shared helpers.

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,24 @@
+---
+description: Echo and Vite React rules for the minimal React template
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+# Echo React Guidelines
+
+## App structure
+- Keep Echo client setup in `src/echo/index.ts`.
+- Use Vite environment variables with the `VITE_` prefix for public app configuration.
+- Keep provider setup near the app root so Echo context is available to child components.
+- Keep browser-only Echo OAuth logic in React components or hooks.
+
+## Echo usage
+- Use the configured Echo React SDK client instead of creating duplicate clients.
+- Do not place provider API keys, wallet private keys, or server secrets in Vite client code.
+- Surface sign-in, balance, insufficient-credit, and request errors in the UI.
+- Keep paid AI actions tied to clear user interactions.
+
+## UI rules
+- Prefer existing components and helpers before adding new abstractions.
+- Keep loading, disabled, and error states accessible.
+- Keep currency formatting centralized in shared utilities.
+- Avoid server-only APIs and Node.js modules in Vite browser code.


### PR DESCRIPTION
## Summary
- Adds `.cursor/rules/echo_rules.mdc` to every `echo-start` template.
- Tailors guidance for Next.js, chat, image/video generation, Auth.js, API-key, React/Vite, and CLI templates instead of sharing one generic rule file.
- Updates the templates README structure example to show the Cursor rules location.

## Verification
- Confirmed all 11 template directories contain `.cursor/rules/echo_rules.mdc`.
- `pnpm` is not available in my local environment, so I could not run the repository format/build scripts. This change only adds Cursor rule markdown files plus one README line.

Closes #636