### PR TITLE
docs: add Echo Cursor rules to templates

### DIFF
--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,44 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## Next.js App Router rules
+
+- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
+- When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
+- Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
+
+## Assistant UI rules
+
+- Keep assistant transport, model/provider configuration, and Echo payment checks in one clearly named integration layer.
+- Validate tool calls and tool results before displaying them or forwarding follow-up context to a model.
+- Use accessible controls for sending, stopping, retrying, and clearing assistant messages.
+- Keep citations, tool output, and reasoning UI distinguishable from normal assistant text.

--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,44 +1,42 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: Assistant UI Echo rules for paid chat streaming, tool calls, and server-only model routes
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo Assistant UI template rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## Next.js App Router rules
 
-- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
-- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
-- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Keep paid provider calls in route handlers, server actions, or server-only modules; client components should call those boundaries rather than importing secret-bearing code.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers; keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, payment-required states, and upstream failures.
 - Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
 - When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
 - Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
 
-## Assistant UI rules
+## Assistant UI template rules
 
-- Keep assistant transport, model/provider configuration, and Echo payment checks in one clearly named integration layer.
-- Validate tool calls and tool results before displaying them or forwarding follow-up context to a model.
-- Use accessible controls for sending, stopping, retrying, and clearing assistant messages.
-- Keep citations, tool output, and reasoning UI distinguishable from normal assistant text.
+- Keep assistant model calls, tool execution, and Echo payment checks behind server routes/actions; UI components should only manage presentation and user intent.
+- Preserve Assistant UI message/thread abstractions and add Echo state as explicit metadata rather than ad-hoc global state.
+- Validate tool inputs and attachment metadata before paid calls, and render tool/provider/payment failures as recoverable assistant states.
+- Prevent duplicate paid runs from optimistic UI updates, reconnects, or repeated submit events.

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,44 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## Next.js App Router rules
+
+- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
+- When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
+- Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
+
+## Auth.js rules
+
+- Keep Auth.js secrets server-side and require `AUTH_SECRET`/provider secrets through environment variables.
+- Check session state before paid Echo actions and return a clear sign-in or authorization error when needed.
+- Do not mix user identity, Echo account identity, and provider credentials in a single untyped object; keep boundaries explicit.
+- Protect callback, session, and account-linking logic from open redirects and accidental secret serialization.

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,44 +1,42 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: Auth.js Echo rules for session-aware paid routes, server-only secrets, and account-safe payment UX
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo Auth.js template rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## Next.js App Router rules
 
-- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
-- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
-- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Keep paid provider calls in route handlers, server actions, or server-only modules; client components should call those boundaries rather than importing secret-bearing code.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers; keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, payment-required states, and upstream failures.
 - Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
 - When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
 - Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
 
-## Auth.js rules
+## Auth.js template rules
 
-- Keep Auth.js secrets server-side and require `AUTH_SECRET`/provider secrets through environment variables.
-- Check session state before paid Echo actions and return a clear sign-in or authorization error when needed.
-- Do not mix user identity, Echo account identity, and provider credentials in a single untyped object; keep boundaries explicit.
-- Protect callback, session, and account-linking logic from open redirects and accidental secret serialization.
+- Keep Auth.js secrets, Echo secrets, and provider keys server-only; do not expose them through session callbacks or client props.
+- Check authenticated user/session state before paid actions and return clear sign-in, payment-required, and authorization errors.
+- Preserve the template's existing Auth.js provider/session flow when adding Echo-protected routes or components.
+- Avoid mixing demo users, wallet/account identifiers, or payment state across sessions; scope cache and UI state to the signed-in user.

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,36 +1,35 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
-globs: **/*.{ts,tsx,js,jsx,json,md,css}
+description: Echo CLI template rules for scriptable paid commands, safe stderr/stdout usage, and secret-free logs
+globs: **/*.{ts,js,json,md}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo CLI template rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## CLI template rules
 
 - Read Echo configuration from environment variables or documented flags, never from hard-coded constants.
-- Exit with non-zero status for invalid input, missing credentials, failed paid calls, and provider errors.
-- Print human-readable progress to stderr and machine-readable command output to stdout when adding scriptable commands.
-- Avoid logging secrets in errors, debug output, shell examples, or generated files.
 - Keep command handlers small: parse arguments, validate, call the Echo/client helper, then format output.
+- Exit with non-zero status for invalid input, missing credentials, failed paid calls, payment-required states, and provider errors.
+- Print human-readable progress and diagnostics to stderr; keep machine-readable command output on stdout when adding scriptable commands.
+- Avoid logging secrets in errors, debug output, shell examples, generated files, or test snapshots.
+- Make retries explicit and safe so a shell loop or transient network retry does not accidentally duplicate paid work.

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,36 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## CLI template rules
+
+- Read Echo configuration from environment variables or documented flags, never from hard-coded constants.
+- Exit with non-zero status for invalid input, missing credentials, failed paid calls, and provider errors.
+- Print human-readable progress to stderr and machine-readable command output to stdout when adding scriptable commands.
+- Avoid logging secrets in errors, debug output, shell examples, or generated files.
+- Keep command handlers small: parse arguments, validate, call the Echo/client helper, then format output.

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,45 +1,42 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: Next.js Echo chat rules for paid streaming, message state, and server-only provider calls
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo Next.js chat template rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## Next.js App Router rules
 
-- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
-- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
-- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Keep paid provider calls in route handlers, server actions, or server-only modules; client components should call those boundaries rather than importing secret-bearing code.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers; keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, payment-required states, and upstream failures.
 - Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
 - When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
 - Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
 
-## Chat and agent UI rules
+## Chat template rules
 
-- Treat chat messages, attachments, and tool inputs as untrusted. Validate or sanitize before forwarding them to paid model/tool calls.
-- Keep message IDs stable and append assistant/tool messages in order so streaming, retry, and payment states remain understandable.
-- Do not log full conversation content by default; redact secrets and personal data in diagnostics.
-- Make model/provider selection explicit and keep defaults in one place.
-- Show a recoverable error when a paid chat request fails so the user can edit or retry without losing the conversation.
+- Keep chat completion, tool, and model-provider calls behind server routes/actions so client components never hold provider secrets.
+- Represent streaming states explicitly: composing, paying, streaming, cancelled, complete, and failed.
+- Preserve conversation history shape and avoid charging for duplicate retries caused by React re-renders, hydration, or stale submit handlers.
+- When adding tools or attachments, validate size/type/content before a paid call and show payment/provider failures in the chat transcript or status area.

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,45 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## Next.js App Router rules
+
+- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
+- When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
+- Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
+
+## Chat and agent UI rules
+
+- Treat chat messages, attachments, and tool inputs as untrusted. Validate or sanitize before forwarding them to paid model/tool calls.
+- Keep message IDs stable and append assistant/tool messages in order so streaming, retry, and payment states remain understandable.
+- Do not log full conversation content by default; redact secrets and personal data in diagnostics.
+- Make model/provider selection explicit and keep defaults in one place.
+- Show a recoverable error when a paid chat request fails so the user can edit or retry without losing the conversation.

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,44 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## Next.js App Router rules
+
+- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
+- When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
+- Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
+
+## Image generation rules
+
+- Validate prompt text, model, size, count, and provider options before spending credits.
+- Show clear pending and completion states, including a safe empty state when no image has been generated yet.
+- Treat generated image URLs and blobs as untrusted external content. Avoid injecting them into raw HTML.
+- Keep prompt-building helpers deterministic and easy to review; do not hide paid prompt expansion in unrelated UI code.

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,44 +1,42 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: Next.js Echo image rules for paid generation routes, prompt validation, and safe result rendering
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo Next.js image template rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## Next.js App Router rules
 
-- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
-- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
-- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Keep paid provider calls in route handlers, server actions, or server-only modules; client components should call those boundaries rather than importing secret-bearing code.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers; keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, payment-required states, and upstream failures.
 - Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
 - When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
 - Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
 
-## Image generation rules
+## Image template rules
 
-- Validate prompt text, model, size, count, and provider options before spending credits.
-- Show clear pending and completion states, including a safe empty state when no image has been generated yet.
-- Treat generated image URLs and blobs as untrusted external content. Avoid injecting them into raw HTML.
-- Keep prompt-building helpers deterministic and easy to review; do not hide paid prompt expansion in unrelated UI code.
+- Validate prompt, model, size, count, and style inputs before the paid image route calls Echo or an image provider.
+- Keep generated image URLs, blobs, or storage keys user-safe; do not serialize provider secrets or raw error payloads to the browser.
+- Show cost/payment-required state before generation and keep retries tied to an explicit user action.
+- Handle slow generation, cancellation, failed moderation/provider responses, and partial results without double-charging the same request.

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,44 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## Next.js App Router rules
+
+- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
+- When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
+- Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
+
+## Video generation rules
+
+- Video jobs may be long-running and expensive. Expose queued, processing, complete, failed, and cancelled states explicitly.
+- Keep polling intervals bounded and stop polling when the component unmounts or the job reaches a terminal state.
+- Validate prompt, duration, aspect ratio, and provider-specific options before creating a paid job.
+- Store only the job metadata needed by the template; do not persist provider secrets or signed URLs longer than necessary.

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,44 +1,42 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: Next.js Echo video rules for long-running paid generation, polling, and safe media result handling
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo Next.js video template rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## Next.js App Router rules
 
-- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
-- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
-- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Keep paid provider calls in route handlers, server actions, or server-only modules; client components should call those boundaries rather than importing secret-bearing code.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers; keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, payment-required states, and upstream failures.
 - Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
 - When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
 - Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
 
-## Video generation rules
+## Video template rules
 
-- Video jobs may be long-running and expensive. Expose queued, processing, complete, failed, and cancelled states explicitly.
-- Keep polling intervals bounded and stop polling when the component unmounts or the job reaches a terminal state.
-- Validate prompt, duration, aspect ratio, and provider-specific options before creating a paid job.
-- Store only the job metadata needed by the template; do not persist provider secrets or signed URLs longer than necessary.
+- Treat video generation as long-running paid work: expose queued, paying, generating, polling, complete, cancelled, and failed states.
+- Keep polling/status routes server-side and avoid exposing provider job tokens, private asset URLs, or raw provider diagnostics to the browser.
+- Validate prompt, duration, aspect ratio, model, and media inputs before spending credits.
+- Make retries idempotent or explicitly user-triggered so a refresh or poll retry does not create duplicate paid jobs.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,42 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## Next.js App Router rules
+
+- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
+- When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
+- Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
+
+## Basic Echo app rules
+
+- Keep the smallest possible example for new users: one clear paid action, one visible result, and one obvious place to configure Echo.
+- Prefer comments that explain Echo-specific flow over comments that restate ordinary React or Next.js syntax.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,42 +1,41 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: Next.js Echo starter rules for server-only paid calls, App Router routes, and safe payment UI
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo Next.js starter rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## Next.js App Router rules
 
-- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
-- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
-- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Keep paid provider calls in route handlers, server actions, or server-only modules; client components should call those boundaries rather than importing secret-bearing code.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers; keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, payment-required states, and upstream failures.
 - Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
 - When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
 - Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
 
-## Basic Echo app rules
+## Basic Next starter rules
 
-- Keep the smallest possible example for new users: one clear paid action, one visible result, and one obvious place to configure Echo.
-- Prefer comments that explain Echo-specific flow over comments that restate ordinary React or Next.js syntax.
+- Keep the example minimal: one clear Echo-protected action, one visible result area, and one obvious place to configure Echo.
+- Put Echo client/server helpers in the existing library location and keep demo UI changes focused on the starter flow.
+- Prefer comments that explain Echo-specific payment/server flow over comments that restate ordinary React or Next.js syntax.

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,44 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## Next.js App Router rules
+
+- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
+- When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
+- Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
+
+## API key and database template rules
+
+- Hash or securely store API keys; never persist plaintext secrets unless the existing schema explicitly documents why.
+- Keep key creation, display-once behavior, revocation, and verification code separate and testable.
+- Use parameterized database queries and migrations instead of string-concatenated SQL.
+- Keep local Docker database defaults development-only and document production replacements in the README.

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,44 +1,42 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: Next.js Echo API-key rules for protected server routes, credential handling, and paid API responses
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo Next.js API-key template rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## Next.js App Router rules
 
-- Keep Echo secrets and paid provider calls in server-only files: route handlers, server actions, or modules that are not imported by client components.
-- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers. Keep server components as the default.
-- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, and payment-required states.
+- Keep paid provider calls in route handlers, server actions, or server-only modules; client components should call those boundaries rather than importing secret-bearing code.
+- Use `'use client'` only for interactive components that need browser APIs, state, or event handlers; keep server components as the default.
+- Validate route handler input before calling Echo or model providers, and return structured error responses for missing credentials, invalid payloads, payment-required states, and upstream failures.
 - Avoid leaking stack traces, tokens, request headers, cookies, or raw provider responses to the browser.
 - When streaming AI responses, handle aborts and provider errors without leaving the UI in a paid-but-stuck state.
 - Keep Next config, middleware, and API routes aligned with the template README so `echo-start` users can copy the example directly.
 
-## API key and database template rules
+## API-key template rules
 
-- Hash or securely store API keys; never persist plaintext secrets unless the existing schema explicitly documents why.
-- Keep key creation, display-once behavior, revocation, and verification code separate and testable.
-- Use parameterized database queries and migrations instead of string-concatenated SQL.
-- Keep local Docker database defaults development-only and document production replacements in the README.
+- Keep API-key validation and Echo payment checks inside server routes or server-only helpers; never move private keys into client components.
+- Validate request method, auth headers, body shape, and content limits before paid work starts.
+- Return consistent JSON errors for missing API keys, invalid credentials, payment-required states, rate limits, and provider failures.
+- Avoid logging full API keys, bearer tokens, request bodies with secrets, or upstream private response payloads.

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,44 +1,41 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: React Echo chat rules for explicit paid sends, streaming status, and safe Vite client configuration
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo React chat template rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## React and Vite rules
 
 - Client-visible Vite variables must use the template's existing `VITE_` names and may only contain public identifiers such as app IDs or public base URLs.
-- Keep paid actions behind clear button/form states: idle, validating, paying/generating, success, and error.
+- Keep paid actions behind explicit user intent with clear button/form states: idle, validating, paying/generating, success, and error.
 - Use React state for user-facing status and keep Echo account/balance components mounted near actions that can spend credits.
 - Avoid starting paid requests during render, hydration, or unguarded `useEffect`; require an explicit user action unless the template already documents otherwise.
 - Keep fetch helpers in `src/lib` and UI-only concerns in `src/components` or `src/App.tsx`.
 
-## Chat and agent UI rules
+## React chat template rules
 
-- Treat chat messages, attachments, and tool inputs as untrusted. Validate or sanitize before forwarding them to paid model/tool calls.
-- Keep message IDs stable and append assistant/tool messages in order so streaming, retry, and payment states remain understandable.
-- Do not log full conversation content by default; redact secrets and personal data in diagnostics.
-- Make model/provider selection explicit and keep defaults in one place.
-- Show a recoverable error when a paid chat request fails so the user can edit or retry without losing the conversation.
+- Require an explicit send action before paid chat work; avoid duplicate sends from re-renders, reconnects, or stale event handlers.
+- Keep message, payment, streaming, cancellation, and error states visible in the chat UI.
+- Validate prompt/message length and attachment metadata before starting a paid request.
+- Keep chat API helpers separate from presentational message components so payment and provider logic remains auditable.

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,44 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## React and Vite rules
+
+- Client-visible Vite variables must use the template's existing `VITE_` names and may only contain public identifiers such as app IDs or public base URLs.
+- Keep paid actions behind clear button/form states: idle, validating, paying/generating, success, and error.
+- Use React state for user-facing status and keep Echo account/balance components mounted near actions that can spend credits.
+- Avoid starting paid requests during render, hydration, or unguarded `useEffect`; require an explicit user action unless the template already documents otherwise.
+- Keep fetch helpers in `src/lib` and UI-only concerns in `src/components` or `src/App.tsx`.
+
+## Chat and agent UI rules
+
+- Treat chat messages, attachments, and tool inputs as untrusted. Validate or sanitize before forwarding them to paid model/tool calls.
+- Keep message IDs stable and append assistant/tool messages in order so streaming, retry, and payment states remain understandable.
+- Do not log full conversation content by default; redact secrets and personal data in diagnostics.
+- Make model/provider selection explicit and keep defaults in one place.
+- Show a recoverable error when a paid chat request fails so the user can edit or retry without losing the conversation.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,43 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## React and Vite rules
+
+- Client-visible Vite variables must use the template's existing `VITE_` names and may only contain public identifiers such as app IDs or public base URLs.
+- Keep paid actions behind clear button/form states: idle, validating, paying/generating, success, and error.
+- Use React state for user-facing status and keep Echo account/balance components mounted near actions that can spend credits.
+- Avoid starting paid requests during render, hydration, or unguarded `useEffect`; require an explicit user action unless the template already documents otherwise.
+- Keep fetch helpers in `src/lib` and UI-only concerns in `src/components` or `src/App.tsx`.
+
+## Image generation rules
+
+- Validate prompt text, model, size, count, and provider options before spending credits.
+- Show clear pending and completion states, including a safe empty state when no image has been generated yet.
+- Treat generated image URLs and blobs as untrusted external content. Avoid injecting them into raw HTML.
+- Keep prompt-building helpers deterministic and easy to review; do not hide paid prompt expansion in unrelated UI code.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,43 +1,41 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: React Echo image rules for explicit paid generation, prompt validation, and safe image state
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo React image template rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## React and Vite rules
 
 - Client-visible Vite variables must use the template's existing `VITE_` names and may only contain public identifiers such as app IDs or public base URLs.
-- Keep paid actions behind clear button/form states: idle, validating, paying/generating, success, and error.
+- Keep paid actions behind explicit user intent with clear button/form states: idle, validating, paying/generating, success, and error.
 - Use React state for user-facing status and keep Echo account/balance components mounted near actions that can spend credits.
 - Avoid starting paid requests during render, hydration, or unguarded `useEffect`; require an explicit user action unless the template already documents otherwise.
 - Keep fetch helpers in `src/lib` and UI-only concerns in `src/components` or `src/App.tsx`.
 
-## Image generation rules
+## React image template rules
 
-- Validate prompt text, model, size, count, and provider options before spending credits.
-- Show clear pending and completion states, including a safe empty state when no image has been generated yet.
-- Treat generated image URLs and blobs as untrusted external content. Avoid injecting them into raw HTML.
-- Keep prompt-building helpers deterministic and easy to review; do not hide paid prompt expansion in unrelated UI code.
+- Require an explicit generate action before paid image work and disable duplicate submissions while payment/generation is in flight.
+- Validate prompt, model, size, count, and style inputs before calling Echo-backed image APIs.
+- Represent empty, generating, partial, complete, and failed result states without clearing useful previous output unexpectedly.
+- Do not render untrusted provider HTML or expose raw provider diagnostics in the browser.

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,41 @@
+---
+description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+globs: **/*.{ts,tsx,js,jsx,json,md,css}
+alwaysApply: true
+---
+
+# Echo template development rules
+
+Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+
+## Core Echo guidelines
+
+- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
+- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
+- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
+- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
+- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
+- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
+- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+
+## TypeScript and quality rules
+
+- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
+- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
+- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
+- Prefer named exports for reusable Echo helpers and UI components.
+- Run the template's lint, type-check, and build scripts after changing implementation files.
+
+## React and Vite rules
+
+- Client-visible Vite variables must use the template's existing `VITE_` names and may only contain public identifiers such as app IDs or public base URLs.
+- Keep paid actions behind clear button/form states: idle, validating, paying/generating, success, and error.
+- Use React state for user-facing status and keep Echo account/balance components mounted near actions that can spend credits.
+- Avoid starting paid requests during render, hydration, or unguarded `useEffect`; require an explicit user action unless the template already documents otherwise.
+- Keep fetch helpers in `src/lib` and UI-only concerns in `src/components` or `src/App.tsx`.
+
+## Basic Echo app rules
+
+- Keep the smallest possible example for new users: one clear paid action, one visible result, and one obvious place to configure Echo.
+- Prefer comments that explain Echo-specific flow over comments that restate ordinary React or Next.js syntax.

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,41 +1,40 @@
 ---
-description: Echo template rules for building monetized AI applications with safe typed SDK usage, clear payment UX, and maintainable TypeScript
+description: React Echo starter rules for explicit paid actions, public Vite env vars, and safe client state
 globs: **/*.{ts,tsx,js,jsx,json,md,css}
 alwaysApply: true
 ---
 
-# Echo template development rules
+# Echo React starter rules
 
-Echo apps combine normal product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
+Echo apps combine product code with metered AI/API calls. Treat payment, identity, and streaming paths as product-critical code: keep them explicit, typed, and easy to audit.
 
-## Core Echo guidelines
+## Core Echo rules
 
-- Keep Echo-related configuration in environment variables documented by the template README or `.env.example`; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
-- Preserve the template's existing Echo SDK boundaries. Extend the existing Echo provider, client, route handler, or CLI wrapper rather than creating duplicate payment/auth plumbing.
-- Validate all user-controlled input before it reaches paid AI/API calls. Prefer typed schemas, narrow interfaces, and explicit error messages.
-- Surface pricing, balance, top-up, and payment-required states in the UI or CLI before retrying paid operations.
-- Keep server-only Echo secrets in server files. Do not expose secret values through `NEXT_PUBLIC_*`, Vite client variables, logs, React props, or serialized responses.
-- When adding an Echo-protected action, include a safe failure path for insufficient funds, missing credentials, provider errors, and cancelled requests.
-- Prefer small composable components/functions over large generated files. Keep Echo-specific code easy to locate and review.
-- Add or update README notes when introducing a new required environment variable, provider, model, route, command, or payment flow.
+- Keep Echo configuration in the template's documented environment variables; never hard-code API keys, app IDs, secrets, wallet addresses, or private endpoints.
+- Preserve the template's existing Echo SDK boundary instead of adding duplicate payment, auth, route, or client plumbing.
+- Validate user-controlled input before paid AI/API calls and return user-safe errors for invalid payloads, missing credentials, insufficient funds, provider failures, and cancelled requests.
+- Make payment state visible before retrying paid operations: pricing, balance/top-up, payment required, generating, success, and error states should be clear in the relevant UI or CLI output.
+- Keep secrets server-only. Do not expose secret values through client env vars, browser props, serialized responses, logs, debug output, examples, or generated files.
+- Add or update README or `.env.example` notes when introducing a required provider, model, route, command, or environment variable.
 
 ## TypeScript and quality rules
 
-- Use strict TypeScript types for request bodies, SDK responses, and component props. Avoid `any` unless the third-party SDK forces it and add a narrowing wrapper immediately.
-- Keep async flows cancellable where practical by threading `AbortSignal` through fetch, model, or SDK calls.
-- Do not swallow Echo or provider errors. Normalize them into user-safe messages while preserving useful diagnostics for developers.
-- Prefer named exports for reusable Echo helpers and UI components.
+- Use strict TypeScript types for request bodies, SDK responses, route results, command options, and component props. Avoid `any` unless a third-party SDK forces it, then narrow immediately.
+- Keep async flows cancellable where practical by passing `AbortSignal` through fetch, model, or SDK calls.
+- Normalize provider/Echo errors into user-safe messages while preserving useful developer diagnostics without secrets.
+- Prefer small named helpers/components over large generated files so Echo-specific code remains easy to review.
 - Run the template's lint, type-check, and build scripts after changing implementation files.
 
 ## React and Vite rules
 
 - Client-visible Vite variables must use the template's existing `VITE_` names and may only contain public identifiers such as app IDs or public base URLs.
-- Keep paid actions behind clear button/form states: idle, validating, paying/generating, success, and error.
+- Keep paid actions behind explicit user intent with clear button/form states: idle, validating, paying/generating, success, and error.
 - Use React state for user-facing status and keep Echo account/balance components mounted near actions that can spend credits.
 - Avoid starting paid requests during render, hydration, or unguarded `useEffect`; require an explicit user action unless the template already documents otherwise.
 - Keep fetch helpers in `src/lib` and UI-only concerns in `src/components` or `src/App.tsx`.
 
-## Basic Echo app rules
+## Basic React starter rules
 
-- Keep the smallest possible example for new users: one clear paid action, one visible result, and one obvious place to configure Echo.
-- Prefer comments that explain Echo-specific flow over comments that restate ordinary React or Next.js syntax.
+- Keep the starter minimal: one obvious paid action, one result area, and one documented Echo configuration path.
+- Put Echo fetch/client helpers in the existing source structure and keep UI code focused on state transitions.
+- Prefer comments that explain Echo-specific payment flow over comments that restate ordinary React syntax.


### PR DESCRIPTION
/claim #636

## Summary
- add `.cursor/rules/echo_rules.mdc` to all 11 echo-start templates
- tailor the rule content for Next.js, React/Vite, chat, image, video, API-key/database, assistant-ui, CLI, and Auth.js templates
- include Echo-specific guidance for safe SDK boundaries, secrets handling, paid action UX, validation, and template quality checks

## Verification
- `corepack pnpm exec prettier --parser markdown --check "templates/**/.cursor/rules/*.mdc"` ✅
- `python3` validation confirmed all 11 expected template rule files exist and include the shared Echo guidance ✅
- `corepack pnpm install --frozen-lockfile` attempted, but the repository `prepare` script failed in this environment with `Unable to find package manager binary: cannot find binary path` after dependencies installed. No implementation code was changed; this PR only adds Cursor `.mdc` rules.
