### PR TITLE
docs: add Cursor rules to Echo templates

### DIFF
--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the Echo Assistant UI template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## Assistant UI specifics
+- Keep `@assistant-ui/react` runtime setup on the client and preserve `AssistantChatTransport` when system messages/tools must be forwarded.
+- Keep Echo model/provider integration in the API route and Echo helper files (`echo.ts`, `providers.tsx`) rather than duplicating clients.
+- Use AI SDK v5 patterns already present in this template; do not downgrade to older `useChat` or route handler APIs.
+- Keep markdown rendering, thread UI, and shadcn/ui components composable and accessible.
+- Preserve `NEXT_PUBLIC_ECHO_APP_ID` configuration and avoid exposing provider API keys to the browser.

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the Auth.js + Echo provider template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## Auth.js + Echo specifics
+- Use `@merit-systems/echo-authjs-provider` for Auth.js provider integration; do not hand-roll OAuth flows.
+- Keep Auth.js server configuration in the existing auth/API files and avoid importing server-only auth helpers into client components.
+- Keep `AUTH_SECRET`, `ECHO_APP_ID`, and `NEXT_PUBLIC_ECHO_APP_ID` in environment variables and document required variables in `.env.example` if they change.
+- Preserve session handling semantics from NextAuth/Auth.js and type auth callbacks explicitly when editing them.
+- Use Echo Next/TypeScript SDK packages only where the existing template already needs them.

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the Echodex Echo CLI template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## Echo CLI specifics
+- Use `@merit-systems/echo-typescript-sdk` and existing `ai-x402` helpers for metered model access; do not introduce browser-only Echo SDK packages.
+- Preserve the command structure in `src/index.ts` and related command modules when adding CLI behavior.
+- Keep credentials in the existing secure storage/keychain abstraction; never print API keys, private keys, or wallet secrets.
+- Use `tsx` for development, `tsc --noEmit` for type checks, and the existing build script for packaged output.
+- Provide clear terminal errors and recovery steps for auth, wallet, network, and balance failures.

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,31 @@
+---
+description: Guidelines for the Echo Next.js chat template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## Next.js chat specifics
+- Keep server SDK setup in `src/echo/index.ts` with `ECHO_APP_ID`, and import `openai`/`anthropic` from `@/echo` inside API routes.
+- Protect chat pages server-side with `isSignedIn()` before rendering paid AI experiences.
+- Use `@merit-systems/echo-next-sdk/client` for `EchoProvider`, `useEcho`, sign-in, balance, and top-up UI, configured from `NEXT_PUBLIC_ECHO_APP_ID`.
+- In chat routes, stream through the AI SDK using Echo model providers so usage is metered automatically.
+- Keep UI components under `src/components` and route-level chat components under `src/app/_components` unless refactoring is explicitly requested.
+- Preserve `biome check --write` as the lint/format command for this template.

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the Echo Next.js image-generation template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## Next.js image specifics
+- Keep image generation routed through server actions/API routes that use Echo-aware providers or documented provider adapters.
+- Never expose provider API keys or payment credentials to client components.
+- Use `ECHO_APP_ID` for server-side Echo setup and `NEXT_PUBLIC_ECHO_APP_ID` for client provider/account UI; keep client hooks inside `use client` files.
+- Keep generated image state separate from Echo auth/balance state so failed billing/auth states are easy to handle.
+- Preserve shadcn/ui component patterns and existing Tailwind utility conventions.

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the Echo Next.js video-generation template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## Next.js video specifics
+- Keep long-running video-generation calls on the server side; do not place provider credentials in client components.
+- Use `ECHO_APP_ID` for server-side Echo setup and `NEXT_PUBLIC_ECHO_APP_ID` for Echo account/balance UI; show clear pending/error states for generation jobs.
+- Preserve existing React Query usage for polling, caching, or job status where present.
+- Avoid blocking route handlers on unnecessary client-only state; separate request creation from status polling.
+- Keep media history and generation UI components focused and typed.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the minimal Echo Next.js template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## Next.js template specifics
+- Wrap client components with the existing `EchoProvider` from `@merit-systems/echo-next-sdk/client` in `src/providers.tsx`.
+- Keep server-side Echo setup centralized in `src/echo/index.ts` with `Echo({ appId: process.env.ECHO_APP_ID! })`.
+- Route Echo webhooks through `src/app/api/echo/[...echo]/route.ts` by re-exporting `handlers`.
+- Use server components by default; add `use client` only for components that call Echo client hooks/components such as `EchoTokens`.
+- Use `ECHO_APP_ID` for server-only Echo configuration and `NEXT_PUBLIC_ECHO_APP_ID` only where client components need the public app identifier.

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the Echo Next.js API-key/database template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## Next.js API-key/database specifics
+- Keep Prisma access in `src/lib/db.ts` and never instantiate Prisma clients in React components.
+- Preserve Echo server setup in `src/echo/index.ts` and client provider setup in `src/providers.tsx`.
+- Store API keys securely: hash or encrypt secrets where the existing code expects it, and never expose raw API keys in client payloads or logs.
+- Keep database setup files (`docker-local-db.yml`, `prisma/schema.prisma`, `env.example`) consistent when changing API-key flows.
+- Use the template's Biome and Prisma scripts when validating relevant changes.

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the Echo React/Vite chat template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## React/Vite chat specifics
+- Use `EchoProvider`, `EchoChatProvider`, `useEcho`, `useChat`, and `useEchoModelProviders` from `@merit-systems/echo-react-sdk` as the integration surface.
+- Keep model provider selection inside the Echo provider context so AI calls remain metered.
+- Use `VITE_ECHO_APP_ID` for browser configuration and do not add server-only env names to client code.
+- Preserve the shared account, balance, top-up, and chat components under `src/components` and `src/chat.tsx`.
+- Handle unauthenticated and zero-balance states explicitly before allowing chat actions.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the Echo React/Vite image template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## React/Vite image specifics
+- Keep image generation UI client-safe: do not introduce server-provider API keys into Vite-exposed code.
+- Use Echo React SDK hooks/components for account state, balances, and top-ups.
+- Keep generated image previews, prompt state, and billing/auth state clearly separated.
+- Preserve the existing Tailwind/shadcn component style and Vite file layout.
+- Use `VITE_ECHO_APP_ID` for Echo browser configuration.

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,30 @@
+---
+description: Guidelines for the minimal Echo React/Vite template.
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.mjs,**/*.cjs
+---
+
+# Echo template guidelines
+
+## Echo principles
+- Keep Echo as the billing/auth boundary: do not bypass Echo model providers with direct OpenAI, Anthropic, or Google SDK calls unless this template already demonstrates a non-Echo provider for a specific reason.
+- Keep Echo App IDs in environment variables. Never hard-code real app IDs, API keys, private keys, wallet keys, or webhook secrets.
+- Prefer the Echo SDK package that matches this template (`@merit-systems/echo-next-sdk`, `@merit-systems/echo-react-sdk`, `@merit-systems/echo-typescript-sdk`, or Auth.js provider) instead of mixing SDKs.
+- Preserve the template's package manager, import aliases, styling stack, and file structure.
+- Keep examples minimal and copy-pasteable for users who generated the template with `echo-start`.
+
+## TypeScript and AI SDK conventions
+- Use explicit TypeScript types for public helpers, route handlers, and SDK wrappers.
+- Keep streaming AI responses compatible with the Vercel AI SDK patterns already used by the template.
+- Prefer existing model provider exports/hooks from the template (`openai`, `anthropic`, `useEchoModelProviders`, or configured clients) over creating new clients.
+- Do not log full prompts, user secrets, API keys, access tokens, payment links, or wallet/private-key data.
+
+## Verification before finishing changes
+- Run the template's local check when practical: lint, build, or typecheck according to `package.json`.
+- If a check depends on external Echo credentials, document that limitation instead of replacing real credentials with fake checked-in values.
+
+## React/Vite template specifics
+- Configure `EchoProvider` from `@merit-systems/echo-react-sdk` in `src/main.tsx` using `import.meta.env.VITE_ECHO_APP_ID`.
+- Keep Echo client UI such as `EchoTokens` inside React components; do not import Next.js Echo SDK packages here.
+- Use `VITE_`-prefixed variables only for values that are safe in the browser.
+- Keep the Vite template simple: avoid adding routing, server code, or backend dependencies unless requested.
+- Validate changes with lint and build commands when practical.


### PR DESCRIPTION
## Summary
- Adds Cursor project rules to each echo-start template under `.cursor/rules/echo_rules.mdc`
- Tailors guidance per template (Next.js, React/Vite, chat, image/video, API-key, Auth.js, assistant-ui, and CLI)
- Emphasizes Echo SDK usage, environment-variable handling, credential safety, and template-specific validation

## Verification
- Validated all 11 Cursor rule files are present with frontmatter and Echo guidance
- Ran `git diff --cached --check`

Closes #636