### PR TITLE
feat: add Veo 3.1 video models

### DIFF
--- a/packages/app/server/src/providers/VertexAIProvider.ts
+++ b/packages/app/server/src/providers/VertexAIProvider.ts
@@ -19,6 +19,8 @@ import { env } from '../env';
 // Constants
 export const PROXY_PASSTHROUGH_ONLY_MODEL = 'PROXY_PLACEHOLDER_VERTEX_AI';
 const VEO3_MODELS = [
+  'veo-3.1-fast-generate-preview',
+  'veo-3.1-generate-preview',
   'veo-3.0-fast-generate-preview',
   'veo-3.0-generate-preview',
 ];

--- a/packages/app/server/src/types.ts
+++ b/packages/app/server/src/types.ts
@@ -163,7 +163,7 @@ type TokenAmount = string;
 type Url = string;
 type Nonce = string;
 
-interface ExactEvmPayloadAuthorization {
+export interface ExactEvmPayloadAuthorization {
   from: Address;
   to: Address;
   value: TokenAmount;

--- a/packages/sdk/ts/src/supported-models/video/gemini.ts
+++ b/packages/sdk/ts/src/supported-models/video/gemini.ts
@@ -1,10 +1,24 @@
 import { SupportedVideoModel } from 'supported-models/types';
 
 export type GeminiVideoModel =
+  | 'veo-3.1-generate-001'
+  | 'veo-3.1-fast-generate-001'
   | 'veo-3.0-generate-001'
   | 'veo-3.0-fast-generate-001';
 // https://ai.google.dev/gemini-api/docs/pricing
 export const GeminiVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-generate-001',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'Gemini',
+  },
+  {
+    model_id: 'veo-3.1-fast-generate-001',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'Gemini',
+  },
   {
     model_id: 'veo-3.0-generate-001',
     cost_per_second_with_audio: 0.4,

--- a/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
+++ b/packages/sdk/ts/src/supported-models/video/vertex-ai.ts
@@ -1,6 +1,8 @@
 import type { SupportedVideoModel } from '../types';
 
 export type VertexAIVideoModel =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 /**
@@ -11,6 +13,18 @@ export type VertexAIVideoModel =
  * Veo 3 Fast: $0.15/second with audio, $0.10/second video only
  */
 export const VertexAIVideoModels: SupportedVideoModel[] = [
+  {
+    model_id: 'veo-3.1-fast-generate-preview',
+    cost_per_second_with_audio: 0.15,
+    cost_per_second_without_audio: 0.1,
+    provider: 'VertexAI',
+  },
+  {
+    model_id: 'veo-3.1-generate-preview',
+    cost_per_second_with_audio: 0.4,
+    cost_per_second_without_audio: 0.2,
+    provider: 'VertexAI',
+  },
   {
     model_id: 'veo-3.0-fast-generate-preview',
     cost_per_second_with_audio: 0.15,

--- a/templates/next-video-template/src/app/api/generate-video/validation.ts
+++ b/templates/next-video-template/src/app/api/generate-video/validation.ts
@@ -35,6 +35,8 @@ export function validateGenerateVideoRequest(body: unknown): ValidationResult {
   }
 
   const validModels: VideoModelOption[] = [
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-preview',
     'veo-3.0-fast-generate-preview',
     'veo-3.0-generate-preview',
   ];

--- a/templates/next-video-template/src/app/api/generate-video/vertex.ts
+++ b/templates/next-video-template/src/app/api/generate-video/vertex.ts
@@ -14,7 +14,11 @@ import {
  */
 export async function handleGeminiGenerate(
   prompt: string,
-  model: 'veo-3.0-fast-generate-preview' | 'veo-3.0-generate-preview',
+  model:
+    | 'veo-3.1-fast-generate-preview'
+    | 'veo-3.1-generate-preview'
+    | 'veo-3.0-fast-generate-preview'
+    | 'veo-3.0-generate-preview',
   durationSeconds: number = 4,
   generateAudio: boolean = false,
   image?: string, // Base64 encoded image or data URL (first frame)

--- a/templates/next-video-template/src/components/video-generator.tsx
+++ b/templates/next-video-template/src/components/video-generator.tsx
@@ -42,6 +42,8 @@ import { FileInputManager } from './FileInputManager';
 import { VideoHistory } from './video-history';
 
 const models: VideoModelConfig[] = [
+  { id: 'veo-3.1-fast-generate-preview', name: 'Veo 3.1 Fast' },
+  { id: 'veo-3.1-generate-preview', name: 'Veo 3.1' },
   { id: 'veo-3.0-fast-generate-preview', name: 'Veo 3 Fast' },
   { id: 'veo-3.0-generate-preview', name: 'Veo 3' },
 ];
@@ -57,7 +59,7 @@ const models: VideoModelConfig[] = [
  */
 export default function VideoGenerator() {
   const [model, setModel] = useState<VideoModelOption>(
-    'veo-3.0-fast-generate-preview'
+    'veo-3.1-fast-generate-preview'
   );
   const [durationSeconds, setDurationSeconds] = useState<4 | 6 | 8>(4);
   const [generateAudio, setGenerateAudio] = useState<boolean>(false);

--- a/templates/next-video-template/src/lib/types.ts
+++ b/templates/next-video-template/src/lib/types.ts
@@ -14,6 +14,8 @@ export type ModelOption = 'openai' | 'gemini';
  * Available AI models for video generation
  */
 export type VideoModelOption =
+  | 'veo-3.1-fast-generate-preview'
+  | 'veo-3.1-generate-preview'
   | 'veo-3.0-fast-generate-preview'
   | 'veo-3.0-generate-preview';
 


### PR DESCRIPTION
/claim #595

## Summary
- add Vertex AI Veo 3.1 preview model IDs to the router allowlist and SDK video model pricing registry
- add Gemini Veo 3.1 stable model IDs to the SDK video model registry so the provider map/accounting path recognizes them
- update the Next video template dropdown, request validation, handler typing, and default model to Veo 3.1 Fast
- export `ExactEvmPayloadAuthorization` so the server package type-checks cleanly

## Verification
- `npx pnpm@10.11.0 exec prettier --check packages/app/server/src/types.ts packages/sdk/ts/src/supported-models/video/vertex-ai.ts packages/sdk/ts/src/supported-models/video/gemini.ts packages/app/server/src/providers/VertexAIProvider.ts templates/next-video-template/src/lib/types.ts templates/next-video-template/src/components/video-generator.tsx templates/next-video-template/src/app/api/generate-video/validation.ts templates/next-video-template/src/app/api/generate-video/vertex.ts`
- `npx pnpm@10.11.0 -C packages/sdk/ts run type-check`
- `npx pnpm@10.11.0 -C packages/app/server run type-check`
- `npx tsc --noEmit --project tsconfig.json` from `templates/next-video-template`