### PR TITLE
feat: add .cursor/rules/echo_rules.mdc to all echo-start templates

### DIFF
--- a/templates/assistant-ui/.cursor/rules/echo_rules.mdc
+++ b/templates/assistant-ui/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,42 @@
+---
+description: Guidelines for building Echo-powered applications with Assistant UI
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo + Assistant UI Guidelines
+
+## Setup
+
+- This template combines Echo with the Assistant UI component library.
+- Use `@merit-systems/echo-next-sdk` for server-side Echo integration.
+- Use `@merit-systems/echo-react-sdk` for client-side auth and providers.
+
+## Using AI Models
+
+- Use `useEchoModelProviders()` to get Echo-wrapped providers:
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+
+const { openai } = useEchoModelProviders();
+```
+
+- NEVER import AI providers directly. Always use Echo-wrapped versions.
+
+## Authentication
+
+- Wrap your app with `<EchoProvider>`.
+- Use `<EchoSignIn />` / `<EchoSignOut />` for auth.
+- Assistant UI components only render for authenticated users.
+
+## Environment Variables
+
+- `NEXT_PUBLIC_ECHO_APP_ID` — Echo app ID (client-safe).
+- `ECHO_APP_SECRET` — Echo app secret (server-only).
+
+## Best Practices
+
+- Echo handles billing and metering; do not add custom usage tracking.
+- Use `<InsufficientFundsModal />` for low balance handling.
+- All AI requests are proxied through Echo for metering — do not bypass.
+- Let Assistant UI handle the chat interface; focus on business logic.

--- a/templates/authjs/.cursor/rules/echo_rules.mdc
+++ b/templates/authjs/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,62 @@
+---
+description: Guidelines for building Echo-powered Next.js applications with the Vercel AI SDK
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo Next.js SDK Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-next-sdk` for Next.js App Router integration.
+- Configure Echo in your API route using `createEchoNextHandler`:
+
+```ts
+import { createEchoNextHandler } from '@merit-systems/echo-next-sdk';
+
+export const { GET, POST } = createEchoNextHandler({
+  appId: process.env.NEXT_PUBLIC_ECHO_APP_ID!,
+  appSecret: process.env.ECHO_APP_SECRET!,
+});
+```
+
+## Authentication
+
+- Wrap your app with `<EchoProvider>` from `@merit-systems/echo-react-sdk`.
+- Use `<EchoSignIn />` and `<EchoSignOut />` components for auth UI.
+- Never store or expose `ECHO_APP_SECRET` on the client side.
+
+## Using AI Models
+
+- Use `useEchoModelProviders()` to get provider instances that route through Echo:
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { generateText } from 'ai';
+
+const { openai, anthropic, google } = useEchoModelProviders();
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+- NEVER import AI providers directly (e.g., `@ai-sdk/openai`). Always use the Echo-wrapped versions.
+- Echo handles authentication, metering, and billing automatically.
+
+## Environment Variables
+
+- `NEXT_PUBLIC_ECHO_APP_ID` — Your Echo app ID (safe for client).
+- `ECHO_APP_SECRET` — Your Echo app secret (server-only, never expose to client).
+- Store these in `.env.local`, never commit them to git.
+
+## Error Handling
+
+- Handle insufficient funds with the `<InsufficientFundsModal />` component.
+- Use `useEcho()` hook to check user balance and session state.
+
+## Best Practices
+
+- Let Echo manage API keys — do not pass API keys to providers manually.
+- Set a markup percentage in the Echo dashboard to earn revenue per token.
+- Use streaming responses via `useChat()` from the Echo React SDK for chat UIs.
+- All AI requests are proxied through Echo for metering; do not bypass the proxy.

--- a/templates/echo-cli/.cursor/rules/echo_rules.mdc
+++ b/templates/echo-cli/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,55 @@
+---
+description: Guidelines for building Echo-powered CLI applications
+globs: **/*.ts,**/*.js
+---
+
+# Echo CLI Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-typescript-sdk` for CLI/Node.js integration.
+- Authenticate using API keys or OAuth token providers:
+
+```ts
+import { EchoClient, ApiKeyTokenProvider } from '@merit-systems/echo-typescript-sdk';
+
+const client = new EchoClient({
+  appId: process.env.ECHO_APP_ID!,
+  tokenProvider: new ApiKeyTokenProvider(process.env.ECHO_API_KEY!),
+});
+```
+
+## Using AI Models
+
+- Use the Echo client to create provider instances:
+
+```ts
+import { createEchoOpenAI } from '@merit-systems/echo-typescript-sdk';
+
+const openai = createEchoOpenAI(client);
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+- NEVER use provider API keys directly. All requests must route through Echo.
+
+## Authentication
+
+- CLI supports both API key auth and OAuth flows.
+- For API key auth, use `ApiKeyTokenProvider`.
+- For OAuth, use `OAuthTokenProvider` with the appropriate flow.
+
+## Environment Variables
+
+- `ECHO_APP_ID` — Your Echo app ID.
+- `ECHO_API_KEY` — API key for authentication.
+- Store in `.env` file, never commit to git.
+
+## Best Practices
+
+- Echo handles metering and billing for all AI requests.
+- Handle errors gracefully — check for insufficient funds errors.
+- Use streaming when possible for better UX in terminal output.
+- Do not bypass the Echo proxy for AI requests.

--- a/templates/next-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/next-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,63 @@
+---
+description: Guidelines for building Echo-powered Next.js chat applications with Vercel AI SDK
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo Next.js Chat Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-next-sdk` for the server-side handler.
+- Use `@merit-systems/echo-react-sdk` for client-side chat components.
+
+## Chat Implementation
+
+- Use `useChat()` from the Echo React SDK for streaming chat:
+
+```tsx
+import { useChat } from '@merit-systems/echo-react-sdk';
+
+function ChatUI() {
+  const { messages, input, handleInputChange, handleSubmit } = useChat();
+  return (
+    <form onSubmit={handleSubmit}>
+      {messages.map(m => <div key={m.id}>{m.content}</div>)}
+      <input value={input} onChange={handleInputChange} />
+    </form>
+  );
+}
+```
+
+- For server-side streaming, use Echo-wrapped providers in your API route:
+
+```ts
+import { streamText } from 'ai';
+import { createEchoOpenAI } from '@merit-systems/echo-next-sdk';
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const openai = createEchoOpenAI(req);
+  const result = streamText({
+    model: openai('gpt-4o'),
+    messages,
+  });
+  return result.toDataStreamResponse();
+}
+```
+
+## Authentication
+
+- Wrap with `<EchoProvider>` and use `<EchoSignIn />` for login.
+- Chat is only available to authenticated users with sufficient balance.
+
+## Environment Variables
+
+- `NEXT_PUBLIC_ECHO_APP_ID` — Echo app ID (client-safe).
+- `ECHO_APP_SECRET` — Echo app secret (server-only).
+
+## Best Practices
+
+- NEVER import `@ai-sdk/openai` or other providers directly; use Echo wrappers.
+- Handle insufficient funds gracefully with `<InsufficientFundsModal />`.
+- Echo meters every streamed token; no custom billing code needed.
+- Use `EchoChatProvider` for full-featured chat context management.

--- a/templates/next-image/.cursor/rules/echo_rules.mdc
+++ b/templates/next-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,62 @@
+---
+description: Guidelines for building Echo-powered Next.js applications with the Vercel AI SDK
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo Next.js SDK Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-next-sdk` for Next.js App Router integration.
+- Configure Echo in your API route using `createEchoNextHandler`:
+
+```ts
+import { createEchoNextHandler } from '@merit-systems/echo-next-sdk';
+
+export const { GET, POST } = createEchoNextHandler({
+  appId: process.env.NEXT_PUBLIC_ECHO_APP_ID!,
+  appSecret: process.env.ECHO_APP_SECRET!,
+});
+```
+
+## Authentication
+
+- Wrap your app with `<EchoProvider>` from `@merit-systems/echo-react-sdk`.
+- Use `<EchoSignIn />` and `<EchoSignOut />` components for auth UI.
+- Never store or expose `ECHO_APP_SECRET` on the client side.
+
+## Using AI Models
+
+- Use `useEchoModelProviders()` to get provider instances that route through Echo:
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { generateText } from 'ai';
+
+const { openai, anthropic, google } = useEchoModelProviders();
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+- NEVER import AI providers directly (e.g., `@ai-sdk/openai`). Always use the Echo-wrapped versions.
+- Echo handles authentication, metering, and billing automatically.
+
+## Environment Variables
+
+- `NEXT_PUBLIC_ECHO_APP_ID` — Your Echo app ID (safe for client).
+- `ECHO_APP_SECRET` — Your Echo app secret (server-only, never expose to client).
+- Store these in `.env.local`, never commit them to git.
+
+## Error Handling
+
+- Handle insufficient funds with the `<InsufficientFundsModal />` component.
+- Use `useEcho()` hook to check user balance and session state.
+
+## Best Practices
+
+- Let Echo manage API keys — do not pass API keys to providers manually.
+- Set a markup percentage in the Echo dashboard to earn revenue per token.
+- Use streaming responses via `useChat()` from the Echo React SDK for chat UIs.
+- All AI requests are proxied through Echo for metering; do not bypass the proxy.

--- a/templates/next-video-template/.cursor/rules/echo_rules.mdc
+++ b/templates/next-video-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,62 @@
+---
+description: Guidelines for building Echo-powered Next.js applications with the Vercel AI SDK
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo Next.js SDK Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-next-sdk` for Next.js App Router integration.
+- Configure Echo in your API route using `createEchoNextHandler`:
+
+```ts
+import { createEchoNextHandler } from '@merit-systems/echo-next-sdk';
+
+export const { GET, POST } = createEchoNextHandler({
+  appId: process.env.NEXT_PUBLIC_ECHO_APP_ID!,
+  appSecret: process.env.ECHO_APP_SECRET!,
+});
+```
+
+## Authentication
+
+- Wrap your app with `<EchoProvider>` from `@merit-systems/echo-react-sdk`.
+- Use `<EchoSignIn />` and `<EchoSignOut />` components for auth UI.
+- Never store or expose `ECHO_APP_SECRET` on the client side.
+
+## Using AI Models
+
+- Use `useEchoModelProviders()` to get provider instances that route through Echo:
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { generateText } from 'ai';
+
+const { openai, anthropic, google } = useEchoModelProviders();
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+- NEVER import AI providers directly (e.g., `@ai-sdk/openai`). Always use the Echo-wrapped versions.
+- Echo handles authentication, metering, and billing automatically.
+
+## Environment Variables
+
+- `NEXT_PUBLIC_ECHO_APP_ID` — Your Echo app ID (safe for client).
+- `ECHO_APP_SECRET` — Your Echo app secret (server-only, never expose to client).
+- Store these in `.env.local`, never commit them to git.
+
+## Error Handling
+
+- Handle insufficient funds with the `<InsufficientFundsModal />` component.
+- Use `useEcho()` hook to check user balance and session state.
+
+## Best Practices
+
+- Let Echo manage API keys — do not pass API keys to providers manually.
+- Set a markup percentage in the Echo dashboard to earn revenue per token.
+- Use streaming responses via `useChat()` from the Echo React SDK for chat UIs.
+- All AI requests are proxied through Echo for metering; do not bypass the proxy.

--- a/templates/next/.cursor/rules/echo_rules.mdc
+++ b/templates/next/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,62 @@
+---
+description: Guidelines for building Echo-powered Next.js applications with the Vercel AI SDK
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo Next.js SDK Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-next-sdk` for Next.js App Router integration.
+- Configure Echo in your API route using `createEchoNextHandler`:
+
+```ts
+import { createEchoNextHandler } from '@merit-systems/echo-next-sdk';
+
+export const { GET, POST } = createEchoNextHandler({
+  appId: process.env.NEXT_PUBLIC_ECHO_APP_ID!,
+  appSecret: process.env.ECHO_APP_SECRET!,
+});
+```
+
+## Authentication
+
+- Wrap your app with `<EchoProvider>` from `@merit-systems/echo-react-sdk`.
+- Use `<EchoSignIn />` and `<EchoSignOut />` components for auth UI.
+- Never store or expose `ECHO_APP_SECRET` on the client side.
+
+## Using AI Models
+
+- Use `useEchoModelProviders()` to get provider instances that route through Echo:
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { generateText } from 'ai';
+
+const { openai, anthropic, google } = useEchoModelProviders();
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+- NEVER import AI providers directly (e.g., `@ai-sdk/openai`). Always use the Echo-wrapped versions.
+- Echo handles authentication, metering, and billing automatically.
+
+## Environment Variables
+
+- `NEXT_PUBLIC_ECHO_APP_ID` — Your Echo app ID (safe for client).
+- `ECHO_APP_SECRET` — Your Echo app secret (server-only, never expose to client).
+- Store these in `.env.local`, never commit them to git.
+
+## Error Handling
+
+- Handle insufficient funds with the `<InsufficientFundsModal />` component.
+- Use `useEcho()` hook to check user balance and session state.
+
+## Best Practices
+
+- Let Echo manage API keys — do not pass API keys to providers manually.
+- Set a markup percentage in the Echo dashboard to earn revenue per token.
+- Use streaming responses via `useChat()` from the Echo React SDK for chat UIs.
+- All AI requests are proxied through Echo for metering; do not bypass the proxy.

--- a/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
+++ b/templates/nextjs-api-key-template/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,62 @@
+---
+description: Guidelines for building Echo-powered Next.js applications with the Vercel AI SDK
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo Next.js SDK Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-next-sdk` for Next.js App Router integration.
+- Configure Echo in your API route using `createEchoNextHandler`:
+
+```ts
+import { createEchoNextHandler } from '@merit-systems/echo-next-sdk';
+
+export const { GET, POST } = createEchoNextHandler({
+  appId: process.env.NEXT_PUBLIC_ECHO_APP_ID!,
+  appSecret: process.env.ECHO_APP_SECRET!,
+});
+```
+
+## Authentication
+
+- Wrap your app with `<EchoProvider>` from `@merit-systems/echo-react-sdk`.
+- Use `<EchoSignIn />` and `<EchoSignOut />` components for auth UI.
+- Never store or expose `ECHO_APP_SECRET` on the client side.
+
+## Using AI Models
+
+- Use `useEchoModelProviders()` to get provider instances that route through Echo:
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { generateText } from 'ai';
+
+const { openai, anthropic, google } = useEchoModelProviders();
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+- NEVER import AI providers directly (e.g., `@ai-sdk/openai`). Always use the Echo-wrapped versions.
+- Echo handles authentication, metering, and billing automatically.
+
+## Environment Variables
+
+- `NEXT_PUBLIC_ECHO_APP_ID` — Your Echo app ID (safe for client).
+- `ECHO_APP_SECRET` — Your Echo app secret (server-only, never expose to client).
+- Store these in `.env.local`, never commit them to git.
+
+## Error Handling
+
+- Handle insufficient funds with the `<InsufficientFundsModal />` component.
+- Use `useEcho()` hook to check user balance and session state.
+
+## Best Practices
+
+- Let Echo manage API keys — do not pass API keys to providers manually.
+- Set a markup percentage in the Echo dashboard to earn revenue per token.
+- Use streaming responses via `useChat()` from the Echo React SDK for chat UIs.
+- All AI requests are proxied through Echo for metering; do not bypass the proxy.

--- a/templates/react-chat/.cursor/rules/echo_rules.mdc
+++ b/templates/react-chat/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,57 @@
+---
+description: Guidelines for building Echo-powered React SPA applications
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo React SDK Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-react-sdk` for client-side React SPA integration.
+- Wrap your app root with `<EchoProvider>`:
+
+```tsx
+import { EchoProvider } from '@merit-systems/echo-react-sdk';
+
+function App() {
+  return (
+    <EchoProvider appId={import.meta.env.VITE_ECHO_APP_ID}>
+      <YourApp />
+    </EchoProvider>
+  );
+}
+```
+
+## Authentication
+
+- Use `<EchoSignIn />` and `<EchoSignOut />` for auth flows.
+- The user authenticates once via OAuth and gets a universal Echo balance.
+
+## Using AI Models
+
+- Use `useEchoModelProviders()` to get Echo-wrapped provider instances:
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { generateText } from 'ai';
+
+const { openai, anthropic, google } = useEchoModelProviders();
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+- NEVER import AI providers directly. Always use the Echo-wrapped versions.
+
+## Environment Variables
+
+- `VITE_ECHO_APP_ID` — Your Echo app ID (client-side).
+- Store in `.env.local`, never commit to git.
+
+## Best Practices
+
+- Echo handles all billing and metering; do not implement custom usage tracking.
+- Use `<InsufficientFundsModal />` for handling low balance scenarios.
+- Use `useEcho()` hook to check user auth state and balance.
+- All AI requests route through Echo's proxy for metering — do not bypass.

--- a/templates/react-image/.cursor/rules/echo_rules.mdc
+++ b/templates/react-image/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,57 @@
+---
+description: Guidelines for building Echo-powered React SPA applications
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo React SDK Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-react-sdk` for client-side React SPA integration.
+- Wrap your app root with `<EchoProvider>`:
+
+```tsx
+import { EchoProvider } from '@merit-systems/echo-react-sdk';
+
+function App() {
+  return (
+    <EchoProvider appId={import.meta.env.VITE_ECHO_APP_ID}>
+      <YourApp />
+    </EchoProvider>
+  );
+}
+```
+
+## Authentication
+
+- Use `<EchoSignIn />` and `<EchoSignOut />` for auth flows.
+- The user authenticates once via OAuth and gets a universal Echo balance.
+
+## Using AI Models
+
+- Use `useEchoModelProviders()` to get Echo-wrapped provider instances:
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { generateText } from 'ai';
+
+const { openai, anthropic, google } = useEchoModelProviders();
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+- NEVER import AI providers directly. Always use the Echo-wrapped versions.
+
+## Environment Variables
+
+- `VITE_ECHO_APP_ID` — Your Echo app ID (client-side).
+- Store in `.env.local`, never commit to git.
+
+## Best Practices
+
+- Echo handles all billing and metering; do not implement custom usage tracking.
+- Use `<InsufficientFundsModal />` for handling low balance scenarios.
+- Use `useEcho()` hook to check user auth state and balance.
+- All AI requests route through Echo's proxy for metering — do not bypass.

--- a/templates/react/.cursor/rules/echo_rules.mdc
+++ b/templates/react/.cursor/rules/echo_rules.mdc
@@ -1,0 +1,57 @@
+---
+description: Guidelines for building Echo-powered React SPA applications
+globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
+---
+
+# Echo React SDK Guidelines
+
+## Setup
+
+- Use `@merit-systems/echo-react-sdk` for client-side React SPA integration.
+- Wrap your app root with `<EchoProvider>`:
+
+```tsx
+import { EchoProvider } from '@merit-systems/echo-react-sdk';
+
+function App() {
+  return (
+    <EchoProvider appId={import.meta.env.VITE_ECHO_APP_ID}>
+      <YourApp />
+    </EchoProvider>
+  );
+}
+```
+
+## Authentication
+
+- Use `<EchoSignIn />` and `<EchoSignOut />` for auth flows.
+- The user authenticates once via OAuth and gets a universal Echo balance.
+
+## Using AI Models
+
+- Use `useEchoModelProviders()` to get Echo-wrapped provider instances:
+
+```tsx
+import { useEchoModelProviders } from '@merit-systems/echo-react-sdk';
+import { generateText } from 'ai';
+
+const { openai, anthropic, google } = useEchoModelProviders();
+const response = await generateText({
+  model: openai('gpt-4o'),
+  prompt: '...',
+});
+```
+
+- NEVER import AI providers directly. Always use the Echo-wrapped versions.
+
+## Environment Variables
+
+- `VITE_ECHO_APP_ID` — Your Echo app ID (client-side).
+- Store in `.env.local`, never commit to git.
+
+## Best Practices
+
+- Echo handles all billing and metering; do not implement custom usage tracking.
+- Use `<InsufficientFundsModal />` for handling low balance scenarios.
+- Use `useEcho()` hook to check user auth state and balance.
+- All AI requests route through Echo's proxy for metering — do not bypass.


### PR DESCRIPTION
## What

Adds `.cursor/rules/echo_rules.mdc` to every echo-start template so Cursor (and other AI editors) understand Echo SDK patterns out of the box.

## Why

When devs scaffold a project with `pnpx echo-start`, their AI coding assistant should immediately know:
- Use Echo-wrapped providers, never raw `@ai-sdk/openai` etc.
- How auth works (EchoProvider, EchoSignIn)
- Which env vars to use
- That Echo handles billing/metering

This prevents AI assistants from generating code that bypasses Echo or uses incorrect imports.

## Templates covered

| Template | Rule focus |
|----------|------------|
| next | Server handler + client providers |
| next-chat | Streaming chat with useChat |
| next-image | Same as next |
| next-video-template | Same as next |
| nextjs-api-key-template | Same as next |
| authjs | Same as next |
| react | Client-only SPA with Vite |
| react-chat | Same as react |
| react-image | Same as react |
| assistant-ui | Echo + Assistant UI |
| echo-cli | Node.js CLI with EchoClient |

## Testing

Opened each template in Cursor and verified the rules load correctly in the rules panel.

Closes #636