### PR TITLE
Add Claude Sonnet 4.6 to supported Anthropic chat models

### DIFF
--- a/packages/sdk/ts/src/supported-models/chat/anthropic.ts
+++ b/packages/sdk/ts/src/supported-models/chat/anthropic.ts
@@ -12,7 +12,8 @@ export type AnthropicModel =
   | 'claude-opus-4-1-20250805'
   | 'claude-opus-4-20250514'
   | 'claude-sonnet-4-20250514'
-  | 'claude-sonnet-4-5-20250929';
+  | 'claude-sonnet-4-5-20250929'
+  | 'claude-sonnet-4-6';
 
 export const AnthropicModels: SupportedModel[] = [
   {
@@ -77,6 +78,12 @@ export const AnthropicModels: SupportedModel[] = [
   },
   {
     model_id: 'claude-sonnet-4-5-20250929',
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    provider: 'Anthropic',
+  },
+  {
+    model_id: 'claude-sonnet-4-6',
     input_cost_per_token: 0.000003,
     output_cost_per_token: 0.000015,
     provider: 'Anthropic',


### PR DESCRIPTION
## What

Registers `claude-sonnet-4-6` — Anthropic's newest Sonnet model — in the SDK's Anthropic supported-models list (`packages/sdk/ts/src/supported-models/chat/anthropic.ts`).

## Why

The model isn't currently in the registry (the list tops out at `claude-sonnet-4-5-20250929`), so apps using Echo can't route requests to it. This adds it so `anthropic("claude-sonnet-4-6")` resolves.

## Details

- Added `claude-sonnet-4-6` to the `AnthropicModel` union type and the `AnthropicModels` array.
- Pricing follows the existing Sonnet tier: `$3/1M` input (`0.000003`), `$15/1M` output (`0.000015`).

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)